### PR TITLE
C library with example clients in C and Swift.  WebAssembly build example.

### DIFF
--- a/experimental/buildBurrExamples
+++ b/experimental/buildBurrExamples
@@ -1,0 +1,39 @@
+#! /bin/sh
+set -ex
+
+#
+# Total Hack...
+#
+
+rm -fv exampleInC
+rm -fv exampleInSwift
+rm -fv *.o
+rm -fv *.d
+
+#
+# Example of linking with a C program:
+#
+gcc -DNO_THREADING -I. -Wall -W -Wextra -I/usr/local/include -g -O2 -c ../src/lib_example_c.c
+gcc -O2 lib_example_c.o libburr.a -o exampleInC -lz -lstdc++
+
+
+#
+# Example of linking with a Swift program:
+#
+swiftc -DNO_THREADING -c ../src/lib_example_swift.swift -import-objc-header ../src/lib_interface.h
+swiftc -lc++  -o exampleInSwift lib_example_swift.o libburr.a
+
+#
+# Run both programs
+#
+
+./exampleInC
+
+./exampleInSwift
+
+#
+# Cleanup
+#
+
+rm -fv *.o
+rm -fv *.d

--- a/experimental/buildLibBurr
+++ b/experimental/buildLibBurr
@@ -1,0 +1,77 @@
+#! /bin/sh
+set -ex
+
+#
+# Total Hack...
+#
+
+rm -fv *.o
+rm -fv *.a
+
+#
+# Build the files needed for the core library
+#
+g++ -DNO_THREADING -I. -Wall -W -Wextra -I/usr/local/include -g -O2 -c \
+        ../src/lib/assembler.cpp   \
+        ../src/lib/assembler_0.cpp \
+        ../src/lib/assembler_1.cpp \
+        ../src/lib/assembly.cpp    \
+        ../src/lib/bt_assert.cpp   \
+        ../src/lib/disasmtomoves.cpp   \
+        ../src/lib/disassembler_0.cpp  \
+        ../src/lib/disassembler_a.cpp  \
+        ../src/lib/disassemblerhashes.cpp  \
+        ../src/lib/disassemblernode.cpp    \
+        ../src/lib/disassembly.cpp \
+        ../src/lib/gridtype.cpp    \
+        ../src/lib/grouping.cpp    \
+        ../src/lib/millable.cpp    \
+        ../src/lib/movementanalysator.cpp  \
+        ../src/lib/movementcache.cpp   \
+        ../src/lib/movementcache_0.cpp \
+        ../src/lib/movementcache_1.cpp \
+        ../src/lib/problem.cpp \
+        ../src/lib/puzzle.cpp  \
+        ../src/lib/solution.cpp    \
+        ../src/lib/solvethread.cpp \
+        ../src/lib/symmetries_0.cpp    \
+        ../src/lib/symmetries_1.cpp    \
+        ../src/lib/symmetries_2.cpp    \
+        ../src/lib/thread.cpp \
+        ../src/lib/voxel.cpp   \
+        ../src/lib/voxel_0.cpp \
+        ../src/lib/voxel_1.cpp \
+        ../src/lib/voxel_2.cpp \
+        ../src/lib/voxel_2_mesh.cpp    \
+        ../src/lib/voxel_3.cpp \
+        ../src/lib/voxel_4.cpp \
+        ../src/lib/voxeltable.cpp  \
+        ../src/tools/xml.cpp   \
+        ../src/lib_interface.cpp   \
+
+#
+# I would prefer to remove these from the core library, but they're currenty tied in..
+#
+g++ -DNO_THREADING -I. -Wall -W -Wextra -I/usr/local/include -g -O2 -c \
+        ../src/lib/stl.cpp \
+        ../src/lib/stl_0.cpp   \
+        ../src/lib/stl_2.cpp   \
+        ../src/halfedge/face.cpp   \
+        ../src/halfedge/halfedge.cpp   \
+        ../src/halfedge/modifiers.cpp  \
+        ../src/halfedge/polyhedron.cpp \
+        ../src/halfedge/vector3.cpp    \
+        ../src/halfedge/vertex.cpp \
+        ../src/halfedge/volume.cpp \
+
+#
+# Bundling object into library
+#
+ar cru libburr.a *.o
+ranlib libburr.a
+
+#
+# Cleanup
+#
+rm *.o
+

--- a/experimental/buildWebAssembly
+++ b/experimental/buildWebAssembly
@@ -1,0 +1,83 @@
+#! /bin/sh
+set -ex
+
+#
+# Total Hack...
+#
+
+rm -fv *.o
+rm -fv *.a
+rm -fv exampleInWebAssembly*
+
+#
+# Build the files needed for the core library
+#
+emcc -DNO_THREADING -I. -Wall -W -Wextra -I/usr/local/include -g -O2 -c \
+        ../src/lib/assembler.cpp   \
+        ../src/lib/assembler_0.cpp \
+        ../src/lib/assembler_1.cpp \
+        ../src/lib/assembly.cpp    \
+        ../src/lib/bt_assert.cpp   \
+        ../src/lib/disasmtomoves.cpp   \
+        ../src/lib/disassembler_0.cpp  \
+        ../src/lib/disassembler_a.cpp  \
+        ../src/lib/disassemblerhashes.cpp  \
+        ../src/lib/disassemblernode.cpp    \
+        ../src/lib/disassembly.cpp \
+        ../src/lib/gridtype.cpp    \
+        ../src/lib/grouping.cpp    \
+        ../src/lib/millable.cpp    \
+        ../src/lib/movementanalysator.cpp  \
+        ../src/lib/movementcache.cpp   \
+        ../src/lib/movementcache_0.cpp \
+        ../src/lib/movementcache_1.cpp \
+        ../src/lib/problem.cpp \
+        ../src/lib/puzzle.cpp  \
+        ../src/lib/solution.cpp    \
+        ../src/lib/solvethread.cpp \
+        ../src/lib/symmetries_0.cpp    \
+        ../src/lib/symmetries_1.cpp    \
+        ../src/lib/symmetries_2.cpp    \
+        ../src/lib/thread.cpp \
+        ../src/lib/voxel.cpp   \
+        ../src/lib/voxel_0.cpp \
+        ../src/lib/voxel_1.cpp \
+        ../src/lib/voxel_2.cpp \
+        ../src/lib/voxel_2_mesh.cpp    \
+        ../src/lib/voxel_3.cpp \
+        ../src/lib/voxel_4.cpp \
+        ../src/lib/voxeltable.cpp  \
+        ../src/tools/xml.cpp   \
+        ../src/lib_interface.cpp 
+
+#
+# I would prefer to remove these from the core library, but they're currenty tied in..
+#
+emcc -DNO_THREADING -I. -Wall -W -Wextra -I/usr/local/include -g -O2 -c \
+        ../src/lib/stl.cpp \
+        ../src/lib/stl_0.cpp   \
+        ../src/lib/stl_2.cpp   \
+        ../src/halfedge/face.cpp   \
+        ../src/halfedge/halfedge.cpp   \
+        ../src/halfedge/modifiers.cpp  \
+        ../src/halfedge/polyhedron.cpp \
+        ../src/halfedge/vector3.cpp    \
+        ../src/halfedge/vertex.cpp \
+        ../src/halfedge/volume.cpp
+
+
+#
+# Example of linking into WebAssembly:
+#
+emcc -I. -Wall -W -Wextra -I/usr/local/include -g -O2 -c ../src/lib_example_c.c
+emcc -O2 *.o -o exampleInWebAssembly.html -lstdc++ 
+
+#
+# Run the program in Node
+#
+node exampleInWebAssembly.js
+
+#
+# Cleanup
+#
+rm -fv *.o

--- a/src/lib/bt_assert.h
+++ b/src/lib/bt_assert.h
@@ -75,7 +75,7 @@ void bt_te(const char * expr, const char * file, unsigned int line, const char *
 
 #else
 
-#ifdef WIN32
+#if defined(WIN32) || defined(EMSCRIPTEN)
 #define __STRING(s) #s
 #endif
 

--- a/src/lib/stl.cpp
+++ b/src/lib/stl.cpp
@@ -40,7 +40,7 @@
  * The concrete classes do the grid dependent stuff and add lots of triangles to the file
  */
 
-#if defined(WIN32) || defined(__APPLE__)
+#if defined(WIN32) || defined(__APPLE__) || defined(EMSCRIPTEN)
 const char * basename(const char * name) {
   const char * res1 = strchr(name, '/');
   const char * res2 = strchr(name, '\\');

--- a/src/lib/thread.cpp
+++ b/src/lib/thread.cpp
@@ -35,14 +35,20 @@ void thread_c::start_thread(void)
 bool thread_c::start() {
 
   running = true;
-  thread = boost::thread(&thread_c::start_thread, this);
+  bool result = false;
 
-  bool result = thread.get_id() != boost::thread::id();
+#ifdef NO_THREADING
+  start_thread();
+  result = true;
+#else
+  thread = boost::thread(&thread_c::start_thread, this);
+  result = thread.get_id() != boost::thread::id();
 
   if (!result)
   {
     running = false;
   }
+#endif
 
   return result;
 }
@@ -50,6 +56,9 @@ bool thread_c::start() {
 void thread_c::kill() {
 
   stop();
+
+#ifndef NO_THREADING
   thread.join();
+#endif
 }
 

--- a/src/lib/thread.h
+++ b/src/lib/thread.h
@@ -21,14 +21,18 @@
 #ifndef __THREAD_H__
 #define __THREAD_H__
 
+#ifndef NO_THREADING
 #include <boost/thread.hpp>
+#endif
 
 /* this class encapsulates a single thread */
 class thread_c {
 
   private:
 
+#ifndef NO_THREADING
     boost::thread thread;  // our thread
+#endif
 
     bool running;
 

--- a/src/lib_example_c.c
+++ b/src/lib_example_c.c
@@ -1,0 +1,104 @@
+/* BurrTools
+ *
+ * BurrTools is the legal property of its developers, whose
+ * names are listed in the COPYRIGHT file, which is included
+ * within the source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "lib_interface.h"
+
+const unsigned long numShapes = 6;
+
+// Based on the CubeInCage example puzzle...
+const char* const shapes[] = {"__________#______#______#______#______#____________________#______+___#######___+______#____________________#_____+++__#+++++#__+++_____#___________#####__#+#+#__#+++#_##+++##_#+++#__#+#+#__#####___________#_____+++__#+++++#__+++_____#____________________#______+___#######___+______#____________________#______#______#______#______#__________",
+    "######___##___##___##___##__#######",
+    "######__###___##___##___##__#######",
+    "_##__####________#",
+    "______________#_____##__________________________________###___________________________________#_____#___________________________________________________________________________________________________________________",
+    "_________________________________________________###_____#_____#_____________________#_#_________#_#_________________________________###________________________________________________________________________________",
+};
+
+int sizes[][3] =
+    { {7,7,7}
+    , {5,7,1}
+    , {5,7,1}
+    , {3,3,2}
+    , {6,6,6}
+    , {6,6,6}
+    };
+
+// Example C-code for creating puzzles..
+int main()
+{
+    printf("Allocating new puzzle\n");
+    puzzle_c *puzzle = alloc_empty_puzzle();
+
+    printf("Allocating new problem\n");
+    unsigned int probIdx = addProblem(puzzle);
+    problem_c *problem = getProblem(puzzle, probIdx);
+
+    // Load the shapes...
+    printf("Loading %lu shapes\n",numShapes);
+    for (unsigned long sId=0; sId < numShapes; sId++ ) {
+        printf("Allocating shape %lu\n", sId);
+        unsigned int shapeIdx = addShape(puzzle, sizes[sId][0], sizes[sId][1], sizes[sId][2]); // Add an empty shape of the given size
+        voxel_c *shape = getShape(puzzle, shapeIdx);
+
+        if ( sId == 0 ) { 
+            // Set the target shape for the problem's result
+            setResultId(problem, 0);
+        } else {
+            printf("   ... setting size\n");
+            setShapeMinimum(problem, shapeIdx, 1);
+            setShapeMaximum(problem, shapeIdx, 1);
+        }
+
+        unsigned int idx = 0;
+        unsigned long sLen = strlen(shapes[sId]);
+        printf("   ... reading %lu voxels\n", sLen);
+        for (unsigned int pos = 0; pos < sLen; pos++) {
+            switch (shapes[sId][pos]) {
+                case '#': setState(shape, idx++, VX_FILLED); break;
+                case '+': setState(shape, idx++, VX_VARIABLE); break;
+                case '_': setState(shape, idx++, VX_EMPTY); break;
+            }
+        }
+    }
+
+    // Shape ID 2 has 2 pieces
+    setShapeMinimum(problem, 2, 2);
+    setShapeMaximum(problem, 2, 2);
+
+    // Group parts 1 & 2 (including both instances of piece 2)
+    setPartGroup(problem, /* partId, not shapeId */ 0, 1, 1);
+    setPartGroup(problem, /* partId, not shapeId */ 1, 1, 2);
+
+    printf("--------------------\n\n");
+    printPuzzleXML(puzzle);
+    printf("--------------------\n\n");
+
+    printf("Solving...\n");
+    solve(puzzle);
+
+    printf("--------------------\n\n");
+    printPuzzleXML(puzzle);
+    printf("--------------------\n\n");
+    printf("Done!\n\n");
+}

--- a/src/lib_example_swift.swift
+++ b/src/lib_example_swift.swift
@@ -1,0 +1,98 @@
+/* BurrTools
+ *
+ * BurrTools is the legal property of its developers, whose
+ * names are listed in the COPYRIGHT file, which is included
+ * within the source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+let numShapes = 6;
+
+// Based on the CubeInCage example puzzle...
+let shapes =
+    [ Array("__________#______#______#______#______#____________________#______+___#######___+______#____________________#_____+++__#+++++#__+++_____#___________#####__#+#+#__#+++#_##+++##_#+++#__#+#+#__#####___________#_____+++__#+++++#__+++_____#____________________#______+___#######___+______#____________________#______#______#______#______#__________")
+    , Array("######___##___##___##___##__#######")
+    , Array("######__###___##___##___##__#######")
+    , Array("_##__####________#")
+    , Array("______________#_____##__________________________________###___________________________________#_____#___________________________________________________________________________________________________________________")
+    , Array("_________________________________________________###_____#_____#_____________________#_#_________#_#_________________________________###________________________________________________________________________________")
+    ];
+
+let sizes =
+    [ [7,7,7]
+    , [5,7,1]
+    , [5,7,1]
+    , [3,3,2]
+    , [6,6,6]
+    , [6,6,6]
+    ];
+
+print("Allocating new puzzle");
+let puzzle = alloc_empty_puzzle();
+
+print("Allocating new problem");
+let probIdx = addProblem(puzzle);
+let problem = getProblem(puzzle, probIdx);
+
+// Load the shapes...
+print("Loading \(numShapes) shapes");
+for sId in 0...numShapes-1 {
+    print("Allocating shape \(sId)");
+    let shapeIdx = addShape(puzzle, UInt32(sizes[sId][0]), UInt32(sizes[sId][1]), UInt32(sizes[sId][2])); // Add an empty shape of the given size
+    let shape = getShape(puzzle, shapeIdx);
+
+    if ( sId == 0 ) { 
+        // Set the target shape for the problem's result
+        setResultId(problem, 0);
+    } else {
+        print("   ... setting size");
+        setShapeMinimum(problem, shapeIdx, 1);
+        setShapeMaximum(problem, shapeIdx, 1);
+    }
+
+    var idx = UInt32(0);
+    let sLen = shapes[sId].count;
+    print("   ... reading \(sLen) voxels");
+    for pos in 0...sLen-1 {
+        switch (shapes[sId][pos]) {
+            case "#": setState(shape, idx, Int32(VX_FILLED.rawValue)); break;
+            case "+": setState(shape, idx, Int32(VX_VARIABLE.rawValue)); break;
+            case "_": setState(shape, idx, Int32(VX_EMPTY.rawValue)); break;
+            default: break;
+        }
+        idx += 1;
+    }
+}
+
+// Shape ID 2 has 2 pieces
+setShapeMinimum(problem, 2, 2);
+setShapeMaximum(problem, 2, 2);
+
+// Group parts 1 & 2 (including both instances of piece 2)
+setPartGroup(problem, /* partId, not shapeId */ 0, 1, 1);
+setPartGroup(problem, /* partId, not shapeId */ 1, 1, 2);
+
+print("--------------------\n\n");
+printPuzzleXML(puzzle);
+print("--------------------\n\n");
+
+print("Solving...\n");
+solve(puzzle);
+
+print("--------------------\n\n");
+printPuzzleXML(puzzle);
+print("--------------------\n\n");
+print("Done!\n\n");

--- a/src/lib_interface.cpp
+++ b/src/lib_interface.cpp
@@ -1,0 +1,172 @@
+/* BurrTools
+ *
+ * BurrTools is the legal property of its developers, whose
+ * names are listed in the COPYRIGHT file, which is included
+ * within the source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include <iostream>
+#include <streambuf>
+
+#include <stdlib.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/time.h>
+
+#include "lib/voxel.h"
+#include "lib/voxel_0.h"
+#include "lib/solution.h"
+#include "lib/problem.h"
+#include "lib/puzzle.h"
+#include "lib/solvethread.h"
+#include "tools/xml.h"
+
+#include "lib_interface.h"
+
+// This is a collection of wrapper functions to enable C-compatable languages to link with the Burr Tools library.
+extern "C"
+{
+
+    // --------------------------------
+    // Voxel (puzzle piece)
+    // --------------------------------
+
+    unsigned int getX(voxel_c *v) { return v->getX(); }
+    unsigned int getY(voxel_c *v) { return v->getY(); }
+    unsigned int getZ(voxel_c *v) { return v->getZ(); }
+
+    unsigned int getXYZ(voxel_c *v) { return v->getXYZ(); }
+    int getIndex(voxel_c *v, unsigned int x, unsigned int y, unsigned int z)  { return v->getIndex(x,y,z); }
+    bool indexToXYZ(voxel_c *v, unsigned int index, unsigned int *x, unsigned int *y, unsigned int *z) { return v->indexToXYZ(index,x,y,z); }
+
+    bool isEmptyXYZ(voxel_c *v, unsigned int x, unsigned int y, unsigned int z)  { return v->isEmpty(x,y,z); }
+    bool isFilledXYZ(voxel_c *v, unsigned int x, unsigned int y, unsigned int z) { return v->isFilled(x,y,z); }
+    bool isVariableXYZ(voxel_c *v, unsigned int x, unsigned int y, unsigned int z) { return v->isVariable(x,y,z); }
+    void setStateXYZ(voxel_c *v, unsigned int x, unsigned int y, unsigned int z, int state) { v->setState(x,y,z,state); }
+    void setColorXYZ(voxel_c *v, unsigned int x, unsigned int y, unsigned int z, unsigned int color) { v->setColor(x,y,z,color); }
+
+    bool isEmpty(voxel_c *v, unsigned int i) { return v->isEmpty(i); }
+    bool isFilled(voxel_c *v, unsigned int i) { return v->isFilled(i); }
+    bool isVariable(voxel_c *v, unsigned int i) { return v->isVariable(i); }
+    void setState(voxel_c *v, unsigned int i, int state)  { v->setState(i,state); }
+    void setColor(voxel_c *v, unsigned int i, unsigned int color)  { v->setColor(i,color); }
+
+    bool validCoordinate(voxel_c *v, int x, int y, int z) { return v->validCoordinate(x,y,z); }
+
+
+    // --------------------------------
+    // Problem
+    // --------------------------------
+
+    void setResultId(problem_c *pr, unsigned int shape) { pr->setResultId(shape); }
+    void clearResult(problem_c *pr) { pr->clearResult(); }
+    bool resultValid(problem_c *pr) { return pr->resultValid(); }
+    unsigned int getResultId(problem_c *pr) { return pr->getResultId(); }
+
+    void removeShapeFromProblem(problem_c *pr, unsigned short shapeId) { pr->removeShape(shapeId); }
+    void setShapeMinimum(problem_c *pr, unsigned int shapeId, unsigned int count) { pr->setShapeMinimum(shapeId,count); }
+    void setShapeMaximum(problem_c *pr, unsigned int shapeId, unsigned int count) { pr->setShapeMaximum(shapeId,count); }
+    unsigned int getShapeMinimum(problem_c *pr, unsigned int shapeId) { return pr->getShapeMinimum(shapeId); }
+    unsigned int getShapeMaximum(problem_c *pr, unsigned int shapeId) { return pr->getShapeMaximum(shapeId); }
+    bool usesShape(problem_c *pr, unsigned int shapeId) { return pr->usesShape(shapeId); }
+    unsigned int getNumberOfPieces(problem_c *pr) { return pr->getNumberOfPieces(); }
+
+    void setPartGroup(problem_c *pr, unsigned int part, unsigned short group, unsigned short count)   { pr->setPartGroup(part,group,count); }
+
+    unsigned int getMaxHoles(problem_c *pr) { return pr->getMaxHoles(); }
+    void setMaxHoles(problem_c *pr, unsigned int value)  { pr->setMaxHoles(value); }
+    void setMaxHolesInvalid(problem_c *pr) { pr->setMaxHolesInvalid(); }
+
+    void removeAllSolutions(problem_c *pr) { pr->removeAllSolutions(); }
+    unsigned long getNumAssemblies(problem_c *pr)  { return pr->getNumAssemblies(); }
+    unsigned long getNumSolutions(problem_c *pr)  { return pr->getNumSolutions(); }
+    unsigned long getUsedTime(problem_c *pr)  { return pr->getUsedTime(); }
+    unsigned int getNumberOfSavedSolutions(problem_c *pr)  { return pr->getNumberOfSavedSolutions(); }
+    solution_c * getSavedSolution(problem_c *pr, unsigned int sol)  { return pr->getSavedSolution(sol); }
+    void removeSolution(problem_c *pr, unsigned int sol) { return pr->removeSolution(sol); }
+    void sortSolutions(problem_c *pr, int by) { return pr->sortSolutions(by); }
+
+
+    // --------------------------------
+    // Puzzle
+    // --------------------------------
+    
+    puzzle_c * alloc_empty_puzzle() { return new puzzle_c(new gridType_c(gridType_c::GT_BRICKS)); };
+    void dealloc_puzzle(puzzle_c **pz) { delete *pz; *pz = 0; }
+
+    unsigned int addShape(puzzle_c *pz, unsigned int sx, unsigned int sy, unsigned int sz)  { return pz->addShape(sx,sy,sz); }
+    unsigned int getNumberOfShapes(puzzle_c *pz) { return pz->getNumberOfShapes(); }
+    voxel_c * getShape(puzzle_c *pz, unsigned int idx)  { return pz->getShape(idx); }
+    void removeShape(puzzle_c *pz, unsigned int idx)  { pz->removeShape(idx); }
+
+    unsigned int addColor(puzzle_c *pz, unsigned char r, unsigned char g, unsigned char b)  { return pz->addColor(r,g,b); }
+    void removeColor(puzzle_c *pz, unsigned int idx)  { pz->removeColor(idx); }
+    void getColor(puzzle_c *pz, unsigned int idx, unsigned char * r, unsigned char * g, unsigned char * b) { pz->getColor(idx,r,g,b); }
+    unsigned int colorNumber(puzzle_c *pz) { return pz->colorNumber(); }
+
+    unsigned int addProblem(puzzle_c *pz)  { return pz->addProblem(); }
+    unsigned int getNumberOfProblems(puzzle_c *pz) { return pz->getNumberOfProblems(); }
+    void removeProblem(puzzle_c *pz, unsigned int p)  { pz->removeProblem(p); }
+    problem_c * getProblem(puzzle_c *pz, unsigned int p)  { return pz->getProblem(p); }
+
+    void printPuzzleXML(puzzle_c *pz) {
+        xmlWriter_c xml(std::cout);
+        pz->save(xml);
+    }
+
+    // --------------------------------
+    // Solver
+    // --------------------------------
+    
+    bool solve(puzzle_c *p)
+    {
+        int par = solveThread_c::PAR_REDUCE;
+        bool restart = false;
+        int filenumber = 0;
+        int firstProblem = 0;
+        int lastProblem = p->getNumberOfProblems();
+
+        restart = true;
+        par |= solveThread_c::PAR_DISASSM;
+
+        for (unsigned int i = 0; i < p->getNumberOfShapes(); i++)
+            p->getShape(i)->initHotspot();
+
+
+        for (int pr = firstProblem ; pr < lastProblem ; pr++) {
+
+            if (restart)
+                p->getProblem(pr)->removeAllSolutions();
+
+            solveThread_c assmThread(*p->getProblem(pr), par);
+
+            // Initialize for new solution attempt
+            assmThread.start(false);
+
+            if (assmThread.currentAction() == solveThread_c::ACT_ERROR) {
+                std::cout << "Exception in Solver\n";
+                std::cout << " file      : " << assmThread.getAssertException().file;
+                std::cout << " function  : " << assmThread.getAssertException().function;
+                std::cout << " line      : " << assmThread.getAssertException().line;
+                std::cout << " expression: " << assmThread.getAssertException().expr;
+                return false;
+            }
+        }
+
+        return true;
+    }
+};

--- a/src/lib_interface.h
+++ b/src/lib_interface.h
@@ -1,0 +1,137 @@
+/* BurrTools
+ *
+ * BurrTools is the legal property of its developers, whose
+ * names are listed in the COPYRIGHT file, which is included
+ * within the source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#ifdef __cplusplus
+extern "C" {
+
+#else
+    typedef struct voxel_c voxel_c;
+    typedef struct solution_c solution_c;
+    typedef struct problem_c problem_c;
+    typedef struct puzzle_c puzzle_c;
+    typedef unsigned char bool;
+#endif
+
+    // This is a collection of wrapper functions to enable C-compatable languages to link with the Burr Tools library.
+
+
+    typedef enum {
+        VX_EMPTY,   ///< This is used for empty voxels
+        VX_FILLED,  ///< This value is used for filled voxels
+        VX_VARIABLE ///< This value is used for voxels with variable content
+    } VoxelState;
+
+    // --------------------------------
+    // Voxel (puzzle piece)
+    // --------------------------------
+
+    unsigned int getX(voxel_c *v) ;
+    unsigned int getY(voxel_c *v) ;
+    unsigned int getZ(voxel_c *v) ;
+
+    unsigned int getXYZ(voxel_c *v) ;
+    int getIndex(voxel_c *v, unsigned int x, unsigned int y, unsigned int z)  ;
+    bool indexToXYZ(voxel_c *v, unsigned int index, unsigned int *x, unsigned int *y, unsigned int *z) ;
+
+    bool isEmptyXYZ(voxel_c *v, unsigned int x, unsigned int y, unsigned int z)  ;
+    bool isFilledXYZ(voxel_c *v, unsigned int x, unsigned int y, unsigned int z) ;
+    bool isVariableXYZ(voxel_c *v, unsigned int x, unsigned int y, unsigned int z) ;
+    void setStateXYZ(voxel_c *v, unsigned int x, unsigned int y, unsigned int z, int state) ;
+    void setColorXYZ(voxel_c *v, unsigned int x, unsigned int y, unsigned int z, unsigned int color) ;
+
+    bool isEmpty(voxel_c *v, unsigned int i) ;
+    bool isFilled(voxel_c *v, unsigned int i) ;
+    bool isVariable(voxel_c *v, unsigned int i) ;
+    void setState(voxel_c *v, unsigned int i, int state)  ;
+    void setColor(voxel_c *v, unsigned int i, unsigned int color)  ;
+
+    bool validCoordinate(voxel_c *v, int x, int y, int z) ;
+
+
+    // --------------------------------
+    // Problem
+    // --------------------------------
+
+    void setResultId(problem_c *pr, unsigned int shape) ;
+    void clearResult(problem_c *pr) ;
+    bool resultValid(problem_c *pr) ;
+    unsigned int getResultId(problem_c *pr) ;
+
+    void removeShapeFromProblem(problem_c *pr, unsigned short shapeId) ;
+    void setShapeMinimum(problem_c *pr, unsigned int shapeId, unsigned int count) ;
+    void setShapeMaximum(problem_c *pr, unsigned int shapeId, unsigned int count) ;
+    unsigned int getShapeMinimum(problem_c *pr, unsigned int shapeId) ;
+    unsigned int getShapeMaximum(problem_c *pr, unsigned int shapeId) ;
+    bool usesShape(problem_c *pr, unsigned int shapeId) ;
+    unsigned int getNumberOfPieces(problem_c *pr) ;
+
+    void setPartGroup(problem_c *pr, unsigned int part, unsigned short group, unsigned short count);
+
+    unsigned int getMaxHoles(problem_c *pr) ;
+    void setMaxHoles(problem_c *pr, unsigned int value)  ;
+    void setMaxHolesInvalid(problem_c *pr) ;
+
+    void removeAllSolutions(problem_c *pr) ;
+    unsigned long getNumAssemblies(problem_c *pr)  ;
+    unsigned long getNumSolutions(problem_c *pr)  ;
+    unsigned long getUsedTime(problem_c *pr)  ;
+    unsigned int getNumberOfSavedSolutions(problem_c *pr)  ;
+    solution_c * getSavedSolution(problem_c *pr, unsigned int sol)  ;
+    void removeSolution(problem_c *pr, unsigned int sol) ;
+    void sortSolutions(problem_c *pr, int by) ;
+
+
+    // --------------------------------
+    // Puzzle
+    // --------------------------------
+    
+    extern puzzle_c * alloc_empty_puzzle() ;;
+    void dealloc_puzzle(puzzle_c **pz) ;
+
+    extern unsigned int addShape(puzzle_c *pz, unsigned int sx, unsigned int sy, unsigned int sz)  ;
+    unsigned int getNumberOfShapes(puzzle_c *pz) ;
+    voxel_c * getShape(puzzle_c *pz, unsigned int idx)  ;
+    void removeShape(puzzle_c *pz, unsigned int idx)  ;
+
+    unsigned int addColor(puzzle_c *pz, unsigned char r, unsigned char g, unsigned char b)  ;
+    void removeColor(puzzle_c *pz, unsigned int idx)  ;
+    void getColor(puzzle_c *pz, unsigned int idx, unsigned char * r, unsigned char * g, unsigned char * b) ;
+    unsigned int colorNumber(puzzle_c *pz) ;
+
+    extern unsigned int addProblem(puzzle_c *pz)  ;
+    unsigned int getNumberOfProblems(puzzle_c *pz) ;
+    void removeProblem(puzzle_c *pz, unsigned int p)  ;
+    problem_c * getProblem(puzzle_c *pz, unsigned int p)  ;
+
+    void printPuzzleXML(puzzle_c *pz);
+
+
+    // --------------------------------
+    // Solver
+    // --------------------------------
+    
+    bool solve(puzzle_c *pz);
+
+
+#ifdef __cplusplus
+}
+#endif
+


### PR DESCRIPTION
Mainly an example of how to link burr-tools with other languages, since C++ is often difficult to interface with.  The example driver programs show how to programmatically build a puzzle by adding pieces, groups, and problems.  Then invoke the library to solve the puzzle and print out the results in XML.

UPDATE:  I have verified that the MacOS, Amazon Linux, and Ubuntu 18.04 platforms build working BurrTxt2 executables after merging brturn-cleanup-build, brturn-little-fixes, and brturn-lib-examples together.  Additionally verified burrGui on MacOS.
