### PR TITLE
Windows 10 (64-bit) build instructions.  Disabled Lua script.  Restored config.h.in

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,6 @@ config.log
 config.status
 doxygen.cfg
 src/config.h
-src/config.h.in
 src/stamp-h1
 src/help/helpdata.cpp
 src/burrTxt
@@ -21,4 +20,8 @@ src/burrTxt2
 src/gui/burrGui
 src/help/helpviewer
 src/unitTest
-src/config.h.in
+src/burrTxt.exe
+src/burrTxt2.exe
+src/gui/burrGui.exe
+src/help/helpviewer.exe
+src/unitTest.exe

--- a/README.build/Windows-10.readme
+++ b/README.build/Windows-10.readme
@@ -1,0 +1,89 @@
+
+------------------------------------------
+Windows 10 (64-bit) bootstrap build
+------------------------------------------
+
+   Instructions to build and run burr-tools from a Windows 10 VM.  This will build the burrTxt2 and burrGui applications.
+
+Issues/Comments?  Join us on GitHub:
+   https://github.com/burr-tools/burr-tools/issues
+
+--------------------------------
+Windows 10 Development VM
+--------------------------------
+
+Download Windows Development VM:
+    https://developer.microsoft.com/en-us/windows/downloads/virtual-machines/
+
+Install MSYS2:
+    https://github.com/msys2/msys2-installer
+
+Use Pacman to install MingW (web page with instructions):
+    https://feaforall.com/install-c-language-gcc-compiler-windows/
+
+--------------------------------
+Downloading Packages
+--------------------------------
+
+> pacman -S base-devel gcc vim cmake
+
+  *** Add PATHs (Start -> Search -> Advanced Control Panel/System Settings -> Environment Variables -> PATH -> Add)
+    C:\msys64\mingw64\bin
+    C:\msys64\usr\bin
+
+> pacman -S 
+    zlib 
+    msys/libpng 
+    msys/zlib-devel 
+    mingw-w64-x86_64-fltk 
+    mingw-w64-x86_64-gcc
+    mingw-w64-x86_64-freeglut 
+    mingw-w64-x86_64-boost 
+    mingw-w64-x86_64-headers-git 
+    mingw-w64-x86_64-winpthreads-git 
+    mingw-w64-x86_64-make
+    mingw-w64-x86_64-libtool
+
+-----------------------------------
+Open MSYS2 - MINGW64 Terminal
+-----------------------------------
+
+  (Start -> MSYS2 64bit -> MSYS2 MinGW 64-bit)
+
+> uname
+MINGW64_NT-10.0-19041
+
+  **** VERIFY uname == MINGW64 ****
+
+--------------------------------
+Download Repo
+--------------------------------
+
+> git clone https://github.com/burr-tools/burr-tools.git
+> cd burr-tools/
+
+-----------------------------------
+Run Configure & Make
+-----------------------------------
+
+> ./bootstrap --with-fltk=/mingw64 --with-libpng=/mingw64 --with-boost=/mingw64
+
+  *** MODIFY:
+     Makefile
+     src/Makefile
+  *** Insert "-lws2_32" after every instance of "-lcomctl32"
+
+> make
+
+-----------------------------------
+Testing burrTxt2
+-----------------------------------
+
+> src/burrTxt2 -R -d examples/CubeInCage.xmpuzzle 
+> ls -al examples
+
+Results:
+-------------------------
+-rw-rw-r-- 1 ec2-user ec2-user  6487 Jul  7 01:44 SolidSixPieceBurrs.xmpuzzle
+-rw-rw-r-- 1 ec2-user ec2-user 25176 Jul  7 01:49 SolidSixPieceBurrs.xmpuzzlettt
+-------------------------

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,0 +1,124 @@
+/* src/config.h.in.  Generated from configure.ac by autoheader.  */
+
+/* Define to the full name of this package. */
+#undef FULLNAME
+
+/* define if the Boost library is available */
+#undef HAVE_BOOST
+
+/* define if the Boost::System library is available */
+#undef HAVE_BOOST_SYSTEM
+
+/* define if the Boost::Test_Exec_Monitor library is available */
+#undef HAVE_BOOST_TEST_EXEC_MONITOR
+
+/* define if the Boost::Thread library is available */
+#undef HAVE_BOOST_THREAD
+
+/* define if the Boost::Unit_Test_Framework library is available */
+#undef HAVE_BOOST_UNIT_TEST_FRAMEWORK
+
+/* Defined if a valid OpenGL implementation is found. */
+#undef HAVE_GL
+
+/* Defined if a valid GLU implementation is found. */
+#undef HAVE_GLU
+
+/* Define to 1 if you have the <GL/glu.h> header file. */
+#undef HAVE_GL_GLU_H
+
+/* Define to 1 if you have the <GL/gl.h> header file. */
+#undef HAVE_GL_GL_H
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+#undef HAVE_INTTYPES_H
+
+/* Define to 1 if you have the `z' library (-lz). */
+#undef HAVE_LIBZ
+
+/* Define to 1 if you have the <memory.h> header file. */
+#undef HAVE_MEMORY_H
+
+/* Define to 1 if you have the <OpenGL/glu.h> header file. */
+#undef HAVE_OPENGL_GLU_H
+
+/* Define to 1 if you have the <OpenGL/gl.h> header file. */
+#undef HAVE_OPENGL_GL_H
+
+/* Define if you have POSIX threads libraries and header files. */
+#undef HAVE_PTHREAD
+
+/* Have PTHREAD_PRIO_INHERIT. */
+#undef HAVE_PTHREAD_PRIO_INHERIT
+
+/* Define to 1 if you have the <stdint.h> header file. */
+#undef HAVE_STDINT_H
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#undef HAVE_STDLIB_H
+
+/* Define to 1 if you have the <strings.h> header file. */
+#undef HAVE_STRINGS_H
+
+/* Define to 1 if you have the <string.h> header file. */
+#undef HAVE_STRING_H
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#undef HAVE_SYS_STAT_H
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#undef HAVE_SYS_TYPES_H
+
+/* Define to 1 if you have the <unistd.h> header file. */
+#undef HAVE_UNISTD_H
+
+/* Use nonstandard varargs form for the GLU tesselator callback */
+#undef HAVE_VARARGS_GLU_TESSCB
+
+/* Define to 1 if you have the <windows.h> header file. */
+#undef HAVE_WINDOWS_H
+
+/* Name of package */
+#undef PACKAGE
+
+/* Define to the address where bug reports for this package should be sent. */
+#undef PACKAGE_BUGREPORT
+
+/* Define to the full name of this package. */
+#undef PACKAGE_NAME
+
+/* Define to the full name and version of this package. */
+#undef PACKAGE_STRING
+
+/* Define to the one symbol short name of this package. */
+#undef PACKAGE_TARNAME
+
+/* Define to the home page for this package. */
+#undef PACKAGE_URL
+
+/* Define to the version of this package. */
+#undef PACKAGE_VERSION
+
+/* Define to necessary symbol if this constant uses a non-standard name on
+   your system. */
+#undef PTHREAD_CREATE_JOINABLE
+
+/* Define to 1 if you have the ANSI C header files. */
+#undef STDC_HEADERS
+
+/* Define to the URL of this package's homepage. */
+#undef URL
+
+/* Version number of package */
+#undef VERSION
+
+/* Enable large inode numbers on Mac OS X 10.5.  */
+#ifndef _DARWIN_USE_64_BIT_INODE
+# define _DARWIN_USE_64_BIT_INODE 1
+#endif
+
+/* Number of bits in a file offset, on hosts where this is settable. */
+#undef _FILE_OFFSET_BITS
+
+/* Define for large files, on AIX-style hosts. */
+#undef _LARGE_FILES

--- a/src/flu/Flu_File_Chooser.cpp
+++ b/src/flu/Flu_File_Chooser.cpp
@@ -2780,7 +2780,7 @@ int Flu_File_Chooser :: popupContextMenu( Entry *entry )
   const Fl_Menu_Item *selection = entryPopup.popup();
   if( selection )
     {
-      long handler = (long)selection->user_data();
+      long handler = reinterpret_cast<uintptr_t>(selection->user_data());
       switch( handler )
 	{
 	case ACTION_NEW_FOLDER:

--- a/src/flu/Flu_Tree_Browser.cpp
+++ b/src/flu/Flu_Tree_Browser.cpp
@@ -2983,7 +2983,7 @@ Flu_Tree_Browser::Node* Flu_Tree_Browser :: add_leaf( const char* path, const ch
 
 unsigned long Flu_Tree_Browser :: remove( const char *fullpath )
 {
-  return( (unsigned long)root.modify( fullpath, Node::REMOVE, rdata ) );
+  return reinterpret_cast<uintptr_t>(root.modify( fullpath, Node::REMOVE, rdata ) );
 }
 
 unsigned long Flu_Tree_Browser :: remove( const char *path, const char *text )

--- a/src/flu/Flu_Tree_Browser.h
+++ b/src/flu/Flu_Tree_Browser.h
@@ -1070,7 +1070,7 @@ class FLU_EXPORT Flu_Tree_Browser : public Fl_Group
       //! Remove the entry identified by path \b fullpath from this node
       /*! \return the unique id of the removed entry, or \c 0 if no matching entry was found */
       inline unsigned long remove( const char *fullpath )
-	{ return( (unsigned long)modify( fullpath, REMOVE, tree->rdata ) ); }
+	{ return reinterpret_cast<uintptr_t>(modify( fullpath, REMOVE, tree->rdata ) ); }
 
       //! Remove the entry identified by unique id \b id from this node
       /*! \return the unique id of the removed entry, or \c 0 if no matching entry was found */

--- a/src/gui/configuration.cpp
+++ b/src/gui/configuration.cpp
@@ -141,7 +141,7 @@ configuration_c::configuration_c(void) {
   CNF_INT("windowposw",           &i_window_pos_w, "800");
   CNF_INT("windowposh",           &i_window_pos_h, "600");
 
-  parse();
+  // parse();
 }
 
 configuration_c::~configuration_c(void) {

--- a/src/help/data2c.cpp
+++ b/src/help/data2c.cpp
@@ -23,6 +23,7 @@
 /* simple program to convert a datafile to C code */
 
 #include <stdio.h>
+#include <cstring>
 #include <libgen.h>
 
 #include <vector>

--- a/src/lib/disassembly.cpp
+++ b/src/lib/disassembly.cpp
@@ -284,7 +284,7 @@ void separation_c::save(xmlWriter_c & xml, int type) const
 
   // first save the pieces array
   xml.newTag("pieces");
-  xml.newAttrib("count", pieces.size());
+  xml.newAttrib("count", (unsigned long)pieces.size());
 
   for (unsigned int ii = 0; ii < pieces.size(); ii++) {
     xml.addContent(pieces[ii]);


### PR DESCRIPTION
Lua script to load config file ~/.burrtools.rc was causing a seg-fault.  Haven't dug any deeper, just commented it out for now.

Bootstrap script was not creating the config.h.in file needed to complete configuration.  Restoring it for this push.
