### PR TITLE
Correct Lua return values, clean up all compiler warnings in BT code

### DIFF
--- a/src/flu/Flu_Tree_Browser.cpp
+++ b/src/flu/Flu_Tree_Browser.cpp
@@ -3500,7 +3500,7 @@ Flu_Tree_Browser::Node* Flu_Tree_Browser :: Node :: modify( const char* path, in
 	// if this is the last node, remove it.
 	if( lastNode )
 	  {
-	    int ID = n->id();
+	    uintptr_t ID = n->id();
 	    _children.erase( n );
 	    //if( tree->rdata.cbNode == n )
 	    //tree->rdata.cbNode = NULL;

--- a/src/flu/Flu_Tree_Browser.cpp
+++ b/src/flu/Flu_Tree_Browser.cpp
@@ -3000,7 +3000,7 @@ unsigned long Flu_Tree_Browser :: remove( const char *path, const char *text )
   return remove( s.c_str() );
 }
 
-unsigned long Flu_Tree_Browser :: remove( unsigned int id )
+std::uintptr_t Flu_Tree_Browser :: remove( std::uintptr_t id )
 {
   return root.remove( id );
 }

--- a/src/flu/Flu_Tree_Browser.h
+++ b/src/flu/Flu_Tree_Browser.h
@@ -19,6 +19,7 @@
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
+#include <cstdint>
 
 //#define USE_FLU_DND
 
@@ -444,7 +445,7 @@ class FLU_EXPORT Flu_Tree_Browser : public Fl_Group
 
   //! Remove the entry identified by unique id \b id from the tree
   /*! \return the unique id of the removed entry, or \c 0 if no matching entry was found */
-  unsigned long remove( unsigned int id );
+  std::uintptr_t remove( std::uintptr_t id );
 
   //! Remove the entry containing the widget \b w from the tree. Note that the widget is automatically destroyed
   /*! \return the unique id of the removed entry, or \c 0 if no matching entry was found */
@@ -920,7 +921,7 @@ class FLU_EXPORT Flu_Tree_Browser : public Fl_Group
 	{ return CHECK(ICON_AT_END); }
 
       //! Get the unique ID of this node
-      inline unsigned int id() const
+      inline std::uintptr_t id() const
 	{ return _id; }
 
       //! Get the index this node is (as a child) in its parent's list
@@ -1073,12 +1074,12 @@ class FLU_EXPORT Flu_Tree_Browser : public Fl_Group
 
       //! Remove the entry identified by path \b fullpath from this node
       /*! \return the unique id of the removed entry, or \c 0 if no matching entry was found */
-      inline unsigned long remove( const char *fullpath )
-	{ return( (unsigned long)modify( fullpath, REMOVE, tree->rdata ) ); }
+      inline std::uintptr_t remove( const char *fullpath )
+        { return( (std::uintptr_t)modify( fullpath, REMOVE, tree->rdata ) ); }
 
       //! Remove the entry identified by unique id \b id from this node
       /*! \return the unique id of the removed entry, or \c 0 if no matching entry was found */
-      unsigned long remove( unsigned int id );
+      std::uintptr_t remove( unsigned int id );
 
       //! Remove the node containing the widget \b w from this node. Note that the widget is automatically destroyed
       /*! \return the unique id of the removed entry, or \c 0 if no matching entry was found */

--- a/src/gui/arcball.h
+++ b/src/gui/arcball.h
@@ -50,6 +50,8 @@ class rotater_c {
      * adds the current arcball transformation to the OpenGL transformation matrix
      */
     virtual void addTransform(void) const = 0;
+
+    virtual ~rotater_c() {};
 };
 
 /**

--- a/src/gui/grideditor_1.cpp
+++ b/src/gui/grideditor_1.cpp
@@ -95,7 +95,7 @@ void gridEditor_1_c::drawNormalTile(int x, int y, int, int tx, int ty, int s, in
 }
 
 void gridEditor_1_c::drawVariableTile(int x, int y, int, int tx, int ty, int s, int s2) {
-  int x1, y1, x2, y2, x3, y3;
+  int x1, y1, x2, x3, y3;
   int x1v, y1v, x2v, y2v, x3v, y3v;
 
   /* find out the coordinates of the 3 corners of the triangle */
@@ -105,7 +105,6 @@ void gridEditor_1_c::drawVariableTile(int x, int y, int, int tx, int ty, int s, 
     x1 = tx+s*x/2;
     y1 = ty-s2-y*s2;
     x2 = x1+s;
-    y2 = y1;
     x3 = x1+s/2;
     y3 = y1+s2;
 
@@ -120,7 +119,6 @@ void gridEditor_1_c::drawVariableTile(int x, int y, int, int tx, int ty, int s, 
     x1 = tx+s*x/2;
     y1 = ty-y*s2;
     x2 = x1+s;
-    y2 = y1;
     x3 = x1+s/2;
     y3 = y1-s2;
 

--- a/src/gui/main.cpp
+++ b/src/gui/main.cpp
@@ -81,7 +81,7 @@ int main(int argc, char ** argv) {
     res = my_Fl::run(ui);
   }
 
-  catch (assert_exception a) {
+  catch (assert_exception& a) {
 
     assertWindow_c * aw = new assertWindow_c("I'm sorry there is a bug in this program. It needs to be closed.\n"
                                              "I try to save the current puzzle in '__rescue.xmpuzzle'\n",

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1902,7 +1902,7 @@ bool mainWindow_c::tryToLoad(const char * f) {
     newPuzzle = new puzzle_c(pars);
   }
 
-  catch (xmlParserException_c e)
+  catch (xmlParserException_c &e)
   {
     fl_message("%s",(std::string("load error: ") + e.what()).c_str());
     delete str;

--- a/src/gui/resultviewer.cpp
+++ b/src/gui/resultviewer.cpp
@@ -50,11 +50,11 @@ void ResultViewer_c::draw(void) {
     else
       snprintf(txt, 19, "Result: S%i", result + 1);
 
-    unsigned char r, g, b;
+    // unsigned char r, g, b;
 
-    r = pieceColorRi(result);
-    g = pieceColorGi(result);
-    b = pieceColorBi(result);
+    // r = pieceColorRi(result);
+    // g = pieceColorGi(result);
+    // b = pieceColorBi(result);
 
     color(fltkPieceColor(result));
     labelcolor(contrastPieceColor(result));

--- a/src/gui/stlexport.cpp
+++ b/src/gui/stlexport.cpp
@@ -407,12 +407,10 @@ void stlExport_c::exportSTL(int shape)
 
   stl->setBinaryMode(Binary->value() != 0);
 
-  int idx = 0;
-
   if (Pname->value() && Pname->value()[0] && Pname->value()[strlen(Pname->value())-1] != '/') {
-      idx = snprintf(name, 1000, "%s/%s", Pname->value(), Fname->value());
+      snprintf(name, 1000, "%s/%s", Pname->value(), Fname->value());
   } else {
-      idx = snprintf(name, 1000, "%s%s", Pname->value(), Fname->value());
+      snprintf(name, 1000, "%s%s", Pname->value(), Fname->value());
   }
 
   if (fileExists(name))

--- a/src/lib/assembler_1.cpp
+++ b/src/lib/assembler_1.cpp
@@ -96,12 +96,17 @@ void printMatrix(
 
   printf("\n");
 
-  for (unsigned int i = 0; i < columns.size(); i++) if (columns[i] > 100) printf("%i", columns[i] / 100); else printf(" "); printf("\n");
-  for (unsigned int i = 0; i < columns.size(); i++) if (columns[i] > 10)  printf("%i", (columns[i] / 10)%10); else printf(" "); printf("\n");
-  for (unsigned int i = 0; i < columns.size(); i++) printf("%i", columns[i] % 10); printf("\n");
+  for (unsigned int i = 0; i < columns.size(); i++) if (columns[i] > 100) printf("%i", columns[i] / 100); else printf(" ");
+  printf("\n");
+  for (unsigned int i = 0; i < columns.size(); i++) if (columns[i] > 10)  printf("%i", (columns[i] / 10)%10); else printf(" ");
+  printf("\n");
+  for (unsigned int i = 0; i < columns.size(); i++) printf("%i", columns[i] % 10);
+  printf("\n");
 
-  for (unsigned int i = 0; i < columns.size(); i++) printf("%i", min[columns[i]]); printf("\n");
-  for (unsigned int i = 0; i < columns.size(); i++) printf("%i", max[columns[i]]); printf("\n");
+  for (unsigned int i = 0; i < columns.size(); i++) printf("%i", min[columns[i]]);
+  printf("\n");
+  for (unsigned int i = 0; i < columns.size(); i++) printf("%i", max[columns[i]]);
+  printf("\n");
 
   std::vector<unsigned int> rows;
 
@@ -368,7 +373,7 @@ int assembler_1_c::prepare(bool hasRange, unsigned int rangeMin, unsigned int ra
       case voxel_c::VX_VARIABLE:
         min[c] = 0;
         holeColumns.push_back(c);
-        // no break;
+        // fall through
       case voxel_c::VX_FILLED:
         columns[i] = c++;
         break;
@@ -1651,8 +1656,7 @@ void assembler_1_c::iterative(void) {
 
         (finished_a.back())++;
 
-        // no break, fall through  to state 3
-
+        // fall through
       case 3:
 
         // add a unhiderows marker, so that the rows hidden in the loop
@@ -1669,8 +1673,7 @@ void assembler_1_c::iterative(void) {
           break;
         }
 
-        // no break, fall through to state 4
-
+	// fall through
       case 4:
 
         row = rows.back();
@@ -1744,14 +1747,12 @@ void assembler_1_c::iterative(void) {
           break;
         }
 
-        // no break, fall through to state 5
-
+        // fall through
       case 5:
 
         unhiderows();
 
-        // no break, fall through to state 6
-
+        // fall through
       case 6:
 
         // remove row from rowset
@@ -1781,8 +1782,7 @@ void assembler_1_c::iterative(void) {
         }
           // else fall through to state 7
 
-        // no break, fall through to state 7
-
+        // fall through
       case 7:
 
         // reinsert all the rows that were remove over the course of the

--- a/src/lib/assembly.cpp
+++ b/src/lib/assembly.cpp
@@ -372,7 +372,9 @@ bool assembly_c::transform(unsigned char trans, const problem_c & puz, const mir
           unsigned int p3;
           unsigned char t_inv;
 
-          bt_assert2(mir->getPieceInfo(p2, &p3, &t_inv));
+          if (! mir->getPieceInfo(p2, &p3, &t_inv)) {
+	      throw assert_exception("piece info could not be found", __FILE__, __LINE__, __PRETTY_FUNCTION__);
+	    };
 
           bt_assert(p3 == p);
 

--- a/src/lib/disassembler_a.cpp
+++ b/src/lib/disassembler_a.cpp
@@ -64,9 +64,6 @@ static void create_new_params(const disassemblerNode_c * st, disassemblerNode_c 
   *n = new disassemblerNode_c(part);
 
   int num = 0;
-  int dx, dy, dz;
-
-  dx = dy = dz = 0;
 
   for (unsigned int i = 0; i < pieces.size(); i++)
     if (st->is_piece_removed(i) == cond) {
@@ -162,10 +159,9 @@ separation_c * disassembler_a_c::checkSubproblems(const disassemblerNode_c * st,
     do {
       state_c *s = new state_c(pieces.size());
 
-      for (unsigned int i = 0; i < pieces.size(); i++)
+      for (unsigned int i = 0; i < pieces.size(); i++) {
 
         if (st2->is_piece_removed(i)) {
-
           /* when the piece is removed in here there must be a
            * predecessor node
            */
@@ -177,10 +173,10 @@ separation_c * disassembler_a_c::checkSubproblems(const disassemblerNode_c * st,
 
         } else
           s->set(i, st2->getX(i), st2->getY(i), st2->getZ(i));
+      }
+      erg->addstate(s);
 
-        erg->addstate(s);
-
-        st2 = st2->getComefrom();
+      st2 = st2->getComefrom();
     } while (st2);
 
   } else {

--- a/src/lua/lauxlib.c
+++ b/src/lua/lauxlib.c
@@ -574,8 +574,7 @@ LUALIB_API int luaL_loadfile (lua_State *L, const char *filename) {
     lf.f = freopen(filename, "rb", lf.f);  /* reopen in binary mode */
     if (lf.f == NULL) return errfile(L, "reopen", fnameindex);
     /* skip eventual `#!...' */
-    while ((c = getc(lf.f)) != EOF && c != LUA_SIGNATURE[0]) 
-      ; // Do nothing
+    while ((c = getc(lf.f)) != EOF && c != LUA_SIGNATURE[0]) {} ; // Do nothing
     lf.extraline = 0;
   }
   ungetc(c, lf.f);

--- a/src/lua/ldebug.c
+++ b/src/lua/ldebug.c
@@ -399,7 +399,7 @@ static Instruction symbexec (const Proto *pt, int lastpc, int reg) {
       case OP_FORLOOP:
       case OP_FORPREP:
         checkreg(pt, a+3);
-        /* go through */
+        /* fall through */
       case OP_JMP: {
         int dest = pc+1+b;
         /* not full check and jump is forward and do not skip `lastpc'? */

--- a/src/lua/llex.c
+++ b/src/lua/llex.c
@@ -365,6 +365,7 @@ static int llex (LexState *ls, SemInfo *seminfo) {
         }
         else if (sep == -1) return '[';
         else luaX_lexerror(ls, "invalid long string delimiter", TK_STRING);
+	break; // not really, we either return or throw an exception
       }
       case '=': {
         next(ls);

--- a/src/lua/ltable.c
+++ b/src/lua/ltable.c
@@ -477,7 +477,7 @@ const TValue *luaH_get (Table *t, const TValue *key) {
       if (luai_numeq(cast_num(k), nvalue(key))) /* index is int? */
         return luaH_getnum(t, k);  /* use specialized version */
       /* else go through */
-    }
+    } // fall through
     default: {
       Node *n = mainposition(t, key);
       do {  /* check whether `key' is somewhere in the chain */

--- a/src/lua/luaclass.cpp
+++ b/src/lua/luaclass.cpp
@@ -55,10 +55,18 @@ bool luaClass_c::getBool(const char *name) {
 
 /* functions to evaluate lua code */
 int luaClass_c::doFile(const char *fname) {
-  luaL_loadfile(L, fname) || lua_pcall(L, 0, 0, 0);
+  int ret = luaL_loadfile(L, fname);
+  if (ret == 0) {
+    return lua_pcall(L, 0, 0, 0);
+  }
+  return ret;
 }
 int luaClass_c::doString(const char *code) {
-  luaL_loadbuffer(L, code, strlen(code), "line") || lua_pcall(L, 0, 0, 0);
+  int ret = luaL_loadbuffer(L, code, strlen(code), "line");
+  if (ret == 0) {
+    return lua_pcall(L, 0, 0, 0);
+  }
+  return ret;
 }
 
 /* functions that allow calling lua functions
@@ -68,12 +76,12 @@ int luaClass_c::doString(const char *code) {
  * the return value is encoded within the name, the othe parameters
  * should be selected by the ...
  */
-void luaClass_c::callV(const char * /*fname*/) {
-}
-void luaClass_c::callV(const char * /*fname*/, lua_Number /*p1*/) {
-}
-lua_Number luaClass_c::callN(const char * /*fname*/) {
-}
-lua_Number luaClass_c::callN(const char * /*fname*/, lua_Number /*p1*/) {
-}
+// void luaClass_c::callV(const char * /*fname*/) {
+// }
+// void luaClass_c::callV(const char * /*fname*/, lua_Number /*p1*/) {
+// }
+// // lua_Number luaClass_c::callN(const char * /*fname*/) {
+// }
+// lua_Number luaClass_c::callN(const char * /*fname*/, lua_Number /*p1*/) {
+// }
 

--- a/src/lua/luaclass.h
+++ b/src/lua/luaclass.h
@@ -55,9 +55,9 @@ class luaClass_c {
      * the return value is encoded within the name, the othe parameters
      * should be selected by the ...
      */
-    void callV(const char * fname);
-    void callV(const char * fname, lua_Number p1);
-    lua_Number callN(const char * fname);
-    lua_Number callN(const char * fname, lua_Number p1);
+    // void callV(const char * fname);
+    // void callV(const char * fname, lua_Number p1);
+    // lua_Number callN(const char * fname);
+    // lua_Number callN(const char * fname, lua_Number p1);
 
 };

--- a/src/tools/xml.cpp
+++ b/src/tools/xml.cpp
@@ -54,7 +54,7 @@ xmlWriter_c::xmlWriter_c(std::ostream & str) : stream(str), state(StBase)
   stream << "<?xml version=\"1.0\"?>\n";
 }
 
-xmlWriter_c::~xmlWriter_c(void)
+xmlWriter_c::~xmlWriter_c(void) noexcept(false)
 {
   if (tagStack.size() > 0)
     throw xmlWriterException_c("Not all tags were closed");
@@ -585,6 +585,8 @@ void xmlParser_c::parseDoctype(bool bpush)
     {
       case -1:
         exception (unexpected_eof);
+	// error, throws exception
+	break; // never reached
       case '\'':
         quoted = !quoted;
         break;

--- a/src/tools/xml.h
+++ b/src/tools/xml.h
@@ -76,7 +76,7 @@ class xmlWriter_c
     xmlWriter_c(std::ostream & str);
 
     /** all tags must be closed by now, otherwise an exception is thrown */
-    ~xmlWriter_c(void);
+    ~xmlWriter_c(void) noexcept(false);
 
     /** start a new tag */
     void newTag(const std::string & name);


### PR DESCRIPTION
There are still warnings in third-party code (mostly FLU)

Make Flu_Tree_Browser::Node::_id an uintptr_t, use uintptr_t in
Flu_Tree_Browser::{remove, modify} as modify can either return an id
or a pointer

rotater_c: Add virtual destructor

Catch exceptions by reference instead of by value

remove unused variables

Reformat lines with for and while loops to make them more legible

mark all fall throughs in switch statements

Don't assert where we always need to check

xmlWriter_c destructor: mark that it can throw exceptions