### PR TITLE
Undo / redo functionality

### DIFF
--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -246,6 +246,7 @@ gui_burrGui_SOURCES += gui/statuswindow.cpp gui/statuswindow.h
 gui_burrGui_SOURCES += gui/stlexport.cpp gui/stlexport.h
 gui_burrGui_SOURCES += gui/togglebutton.cpp gui/togglebutton.h
 gui_burrGui_SOURCES += gui/tooltabs.cpp gui/tooltabs.h
+gui_burrGui_SOURCES += gui/undomanager.cpp gui/undomanager.h
 gui_burrGui_SOURCES += gui/vectorexportwindow.cpp gui/vectorexportwindow.h
 gui_burrGui_SOURCES += gui/view3dgroup.cpp gui/view3dgroup.h
 gui_burrGui_SOURCES += gui/voxelframe.cpp gui/voxelframe.h

--- a/src/gui/BlockList.cpp
+++ b/src/gui/BlockList.cpp
@@ -806,15 +806,15 @@ int ColorConstraintsEdit::handle(int event) {
   unsigned int ypos = 0;
 
   /* nothing there */
-  if ((w() <= 0) || (h() <= 0)) return 1;
+  if ((w() <= 0) || (h() <= 0)) return 0;
 
   /* only handle push */
   if (event != FL_PUSH)
-    return 1;
+    return 0;
 
   /* no valid problem available */
   if (problem >= puzzle->getNumberOfProblems())
-    return 1;
+    return 0;
 
   /* find out the group that we clicked onto */
   for (unsigned int c1 = 0; c1 < puzzle->colorNumber(); c1++) {
@@ -845,11 +845,11 @@ int ColorConstraintsEdit::handle(int event) {
         redraw();
         do_callback(RS_CHANGEDSELECTION);
       }
-      break;
+      return 1;
     }
   }
 
-  return 1;
+  return 0;
 }
 
 void ColorConstraintsEdit::setSelection(unsigned int num) {

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -34,6 +34,7 @@ class disasmToMoves_c;
 class gridType_c;
 class guiGridType_c;
 class layouter_c;
+class UndoManager_c;
 
 class PieceSelector;
 class ProblemSelector;
@@ -68,8 +69,8 @@ class mainWindow_c : public LFl_Double_Window {
   disasmToMoves_c * disassemble;
   solveThread_c *assmThread;
   bool SolutionEmpty;
-  bool changed;
   int editSymmetries;
+  UndoManager_c * undoManager;
 
   bool expertMode;
 
@@ -163,7 +164,7 @@ class mainWindow_c : public LFl_Double_Window {
   void changeProblem(unsigned int nr);
   void changeColor(unsigned int nr);
 
-  void ReplacePuzzle(puzzle_c * newPuzzle);
+  void ReplacePuzzle(puzzle_c * newPuzzle, bool keepSelections);
 
   void activateShape(unsigned int number);
   void activateProblem(unsigned int prob);
@@ -271,6 +272,8 @@ public:
   void cb_Load_Ps3d(void);
   void cb_Save(void);
   void cb_SaveAs(void);
+  void cb_Undo(void);
+  void cb_Redo(void);
   void cb_Convert(void);
   void cb_AssembliesToShapes(void);
   void cb_Quit(void);

--- a/src/gui/undomanager.cpp
+++ b/src/gui/undomanager.cpp
@@ -1,0 +1,115 @@
+
+/* BurrTools
+ *
+ * BurrTools is the legal property of its developers, whose
+ * names are listed in the COPYRIGHT file, which is included
+ * within the source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+#include "undomanager.h"
+
+#include "../lib/puzzle.h"
+#include "../lib/problem.h"
+#include "../tools/xml.h"
+
+#include <sstream>
+
+/**
+ * Return true if any problem in the puzzle is currently being solved.
+ */
+static bool puzzleIsBeingSolved(puzzle_c *puzzle) {
+  for (unsigned int i=0; i<puzzle->getNumberOfProblems(); i++) {
+    if(puzzle->getProblem(i)->getSolveState() == SS_SOLVING) {
+      return true;
+    }
+  }
+  return false;
+}
+
+UndoManager_c::UndoManager_c(void) {
+    currentState = -1;
+    savedState = -1;
+}
+UndoManager_c::~UndoManager_c(void) { }
+
+void UndoManager_c::loadNew(puzzle_c * puzzle) {
+  currentState = -1;
+  savedState = -1;
+  states.resize(0);
+
+  recordState(puzzle, "Loaded Puzzle");
+  markSaved();
+}
+
+void UndoManager_c::recordState(puzzle_c * puzzle, std::string description) {
+
+  // For thread safety, skip recording if a problem is being solved.
+  // See discussion of thread safety in undomanager.h.
+  if (puzzleIsBeingSolved(puzzle)) {
+    return;
+  }
+
+  std::ostringstream stateString;
+  xmlWriter_c xml(stateString);
+  puzzle->save(xml);
+
+  if (savedState > currentState) {
+    savedState = -1;
+  }
+
+  states.resize(currentState+1);
+  states.push_back({
+    .xml = stateString.str(),
+    .description = description,
+  });
+  currentState = states.size()-1;
+}
+
+puzzle_c * UndoManager_c::undo(std::string *description_out) {
+  if (!canUndo()) { return NULL; }
+  *description_out = states[currentState].description;
+  currentState--;
+
+  std::istringstream stateString(states[currentState].xml);
+  xmlParser_c xml(stateString);
+  return new puzzle_c(xml);
+}
+
+puzzle_c * UndoManager_c::redo(std::string *description_out) {
+  if (!canRedo()) { return NULL; }
+  currentState++;
+  *description_out = states[currentState].description;
+
+  std::istringstream stateString(states[currentState].xml);
+  xmlParser_c xml(stateString);
+  return new puzzle_c(xml);
+}
+
+bool UndoManager_c::canUndo(void) {
+  return currentState > 0;
+}
+
+bool UndoManager_c::canRedo(void) {
+  return currentState >= 0 && currentState < (int) states.size()-1;
+}
+
+void UndoManager_c::markSaved(void) {
+  savedState = currentState;
+}
+
+bool UndoManager_c::isChanged(void) {
+  return currentState != -1 && currentState != savedState;
+}

--- a/src/gui/undomanager.h
+++ b/src/gui/undomanager.h
@@ -1,0 +1,123 @@
+/* BurrTools
+ *
+ * BurrTools is the legal property of its developers, whose
+ * names are listed in the COPYRIGHT file, which is included
+ * within the source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+#ifndef __UNDO_MANAGER_H__
+#define __UNDO_MANAGER_H__
+
+#include "../lib/puzzle.h"
+
+#include <string>
+
+/**
+ * Manages saving and loading states for undo and redo.
+ *
+ * There are a few thread safety issues to consider here:
+ *
+ * 1) We don't want to record states while the solve thread is running, since
+ * solutions could be added in the solve thread, and we don't want to undo
+ * those additions.
+ *
+ * 2) We can't undo or redo while the solve thread is running. Doing so could
+ * crash the solver thread due to changes in the puzzle (for example deleting a
+ * piece the solve thread was using). This is normally prevented by disabling
+ * edits in the GUI.
+ *
+ * 3) Calling recordState/undo/redo could also read or write the puzzle in the
+ * middle of an update from the solve thread, possibly at an inconsistent
+ * state.
+ *
+ * Here's how the user of this class (mainWindow_c) must handle thread safety:
+ *   * Do not call undo or redo while the solve thread is running.
+ *   * Be aware that recordState is a no-op if a problem is being solved in the
+ *     given puzzle. This is not usually a problem since the user can't make
+ *     most edits while the puzzle is being solved anyways.
+ *
+ * This leaves one quirk of how mainWindow_c uses this class: since it calls
+ * recordState at the end of solving, an undo after solving finishes will undo
+ * all changes made during the solve.
+ */
+class UndoManager_c {
+
+public:
+
+  UndoManager_c(void);
+  ~UndoManager_c(void);
+
+  /**
+   * Starts a new set of undo history. Called when a new puzzle is loaded or created.
+   */
+  void loadNew(puzzle_c * puzzle);
+
+  /**
+   * Saves the current state of the puzzle for undo. The given description
+   * should describe the change which was made from the last recorded state.
+   */
+  void recordState(puzzle_c * puzzle, std::string description);
+
+  /**
+   * Returns the puzzle from the previous state in the undo history, and sets that
+   * state as current. Returns NULL if there is nothing to undo.
+   * `description_out` will be set to a description of the change which was
+   * undone.
+   */
+  puzzle_c * undo(std::string *description_out);
+
+  /**
+   * Returns the puzzle from the next state in the undo history, and sets that state
+   * as current. Returns NULL if there is nothing to redo.
+   * `description_out` will be set to a description of the change which was
+   * undone.
+   */
+  puzzle_c * redo(std::string *description_out);
+
+  /**
+   * Returns true if there is something to undo.
+   */
+  bool canUndo(void);
+
+  /**
+   * Returns true if there is something to redo.
+   */
+  bool canRedo(void);
+
+  /**
+   * Marks the current state as saved to disk, so isChanged() will return false.
+   */
+  void markSaved(void);
+
+  /**
+   * Returns true if the currently saved state is not saved to disk.
+   */
+  bool isChanged(void);
+
+private:
+
+  typedef struct {
+    std::string xml;
+    std::string description;
+  } UndoState;
+
+  std::vector<UndoState> states;
+  int currentState;
+  int savedState;
+
+};
+
+#endif


### PR DESCRIPTION
This implements undo and redo by saving the full state of the puzzle after each change. Under the file menu is now an option to undo and redo, with keyboard shortcuts Ctrl+Z and Ctrl+Y.

Undo history is saved in XML format for now, since that was easiest way to make the implementation obviously correct. We may need to do something more intelligent in the future, as this takes more time and space than simply copying the data structure, even though that would be more difficult.

In order to avoid thread safety issues, undo and redo is disabled while the solve thread is running. Undo states are also not recorded while the solve thread is running. This means that performing an undo after a solve finishes will undo all changes performed during the solve. This isn't usually a problem since most ways to edit the puzzle are disabled while solving. See the comment in undomanager.h for a full discussion of handling thread safety.

Along with the actual puzzle state, we also store a message about what edit was made which is displayed later when the user performs an undo or redo.

There is a small second commit which fixes an issue where keyboard shortcuts, like "F3" for loading a new puzzle, would not work while on the "Puzzle" activity tab.

----

Because this is a large enough change, before this merges I'd like some beta testing testing and input on some of the design decisions I've made. Specifically:
* Does this work well with people's usual workflow?
* Does storing undo states as XML take up too much memory for large puzzles?
* Does storing undo states take too long for large puzzles?

The largest puzzle I have 67 MB. It takes ~0.5 seconds to save, and (if you don't modify any pieces used, which clears solutions) each undo state takes up the same 67 MB. I feel like this is a pretty rare case though. I can think of a few options for addressing speed and memory concerns:

* Delete the oldest undo state when the total size exceeds a threshold
* Copy the puzzle directly in memory instead of converting to and from XML
* Add an option to disable undo
* Compress the data while stored
* Consider it a rare case that doesn't need to be fixed
* Consider it good enough for now but work on one of the above in the future (I'm of course willing to do this)
