### PR TITLE
Add bulk piece range setter and shape selection helpers

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -116,6 +116,7 @@ gui_src = [
   'src/gui/arcball.cpp',
   'src/gui/assertwindow.cpp',
   'src/gui/assmimportwindow.cpp',
+  'src/gui/bulkrangewindow.cpp',
   'src/gui/blocklistgroup.cpp',
   'src/gui/buttongroup.cpp',
   'src/gui/configuration.cpp',

--- a/src/gui/bulkrangewindow.cpp
+++ b/src/gui/bulkrangewindow.cpp
@@ -1,0 +1,79 @@
+/* BurrTools
+ *
+ * BurrTools is the legal property of its developers, whose
+ * names are listed in the COPYRIGHT file, which is included
+ * within the source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+
+#include "bulkrangewindow.h"
+
+#include "Layouter.h"
+#include "separator.h"
+
+#include <stdlib.h>
+#include <FL/Fl_Int_Input.H>
+
+static void cb_Ok_stub    (Fl_Widget* /*o*/, void* v) { ((bulkRangeWindow_c*)v)->okay_cb(); }
+static void cb_Cancel_stub(Fl_Widget* /*o*/, void* v) { ((bulkRangeWindow_c*)v)->hide(); }
+
+void bulkRangeWindow_c::okay_cb(void) {
+  _ok = true;
+  hide();
+}
+
+bulkRangeWindow_c::bulkRangeWindow_c(void) : LFl_Double_Window(false), _ok(false) {
+
+  int ypos = 0;
+
+  layouter_c * o = new layouter_c(0, 0);
+  o->pitch(5);
+
+  new LSeparator_c(0, ypos++, 1, 1, "Set Range for All Pieces", false);
+
+  {
+    layouter_c * row = new layouter_c(0, ypos++);
+
+    (new LFl_Box("Min count", 0, 0))->stretchRight();
+    (new LFl_Box("Max count", 0, 1))->stretchRight();
+    (new LFl_Box("", 1, 0))->setMinimumSize(5, 0);
+    minInput = new LFl_Int_Input(2, 0);
+    maxInput = new LFl_Int_Input(2, 1);
+    minInput->value("0");
+    maxInput->value("1");
+
+    ((LFl_Int_Input*)minInput)->weight(1, 0);
+
+    row->end();
+  }
+
+  new LSeparator_c(0, ypos++, 1, 1, "", false);
+
+  o->end();
+
+  o = new layouter_c(0, 1);
+  o->pitch(5);
+
+  (new LFl_Button("Apply to All", 0, 0, 1, 1))->callback(cb_Ok_stub, this);
+  (new LFl_Button("Cancel",       1, 0, 1, 1))->callback(cb_Cancel_stub, this);
+
+  o->end();
+
+  label("Bulk Set Piece Range");
+}
+
+unsigned int bulkRangeWindow_c::getMin(void) const { return (unsigned int)atoi(minInput->value()); }
+unsigned int bulkRangeWindow_c::getMax(void) const { return (unsigned int)atoi(maxInput->value()); }

--- a/src/gui/bulkrangewindow.h
+++ b/src/gui/bulkrangewindow.h
@@ -1,0 +1,50 @@
+/* BurrTools
+ *
+ * BurrTools is the legal property of its developers, whose
+ * names are listed in the COPYRIGHT file, which is included
+ * within the source distribution.
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
+ */
+#ifndef __BULKRANGE_WINDOW_H__
+#define __BULKRANGE_WINDOW_H__
+
+#include "Layouter.h"
+
+class Fl_Int_Input;
+
+/* Dialog that lets the user specify a min/max piece count range and apply
+ * it to every shape in the current problem at once.
+ */
+class bulkRangeWindow_c : public LFl_Double_Window {
+
+  private:
+
+    bool _ok;
+    Fl_Int_Input *minInput, *maxInput;
+
+  public:
+
+    bulkRangeWindow_c(void);
+
+    bool okSelected(void) const { return _ok; }
+
+    void okay_cb(void);
+
+    unsigned int getMin(void) const;
+    unsigned int getMax(void) const;
+};
+
+#endif

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -49,6 +49,7 @@
 #include "vectorexportwindow.h"
 #include "convertwindow.h"
 #include "assmimportwindow.h"
+#include "bulkrangewindow.h"
 
 #include "LFl_Tile.h"
 
@@ -773,6 +774,47 @@ void mainWindow_c::cb_RemoveAllShapesFromProblem(void) {
 
   for (unsigned int i = 0; i < puzzle->getNumberOfShapes(); i++)
     pr->setShapeMaximum(i, 0);
+
+  changed = true;
+  PiecesCountList->redraw();
+  PcVis->setPuzzle(puzzle->getProblem(solutionProblem->getSelection()));
+
+  activateProblem(problemSelector->getSelection());
+  StatProblemInfo(problemSelector->getSelection());
+}
+
+static void cb_SetAllRange_stub(Fl_Widget* /*o*/, void* v) { ((mainWindow_c*)v)->cb_SetAllRange(); }
+void mainWindow_c::cb_SetAllRange(void) {
+
+  if (problemSelector->getSelection() >= puzzle->getNumberOfProblems()) {
+    fl_message("First create a problem");
+    return;
+  }
+
+  bulkRangeWindow_c win;
+  win.show();
+  while (win.visible())
+    Fl::wait();
+
+  if (!win.okSelected())
+    return;
+
+  unsigned int prob = problemSelector->getSelection();
+  changeProblem(prob);
+
+  problem_c * pr = puzzle->getProblem(prob);
+
+  unsigned int newMin = win.getMin();
+  unsigned int newMax = win.getMax();
+  if (newMin > newMax)
+    newMax = newMin;
+
+  for (unsigned int i = 0; i < puzzle->getNumberOfShapes(); i++) {
+    if (pr->resultValid() && i == pr->getResultId())
+      continue;
+    pr->setShapeMaximum(i, newMax);
+    pr->setShapeMinimum(i, newMin);
+  }
 
   changed = true;
   PiecesCountList->redraw();
@@ -2427,9 +2469,11 @@ void mainWindow_c::updateInterface(void) {
         (!assmThread || (&(assmThread->getProblem()) != puzzle->getProblem(problemSelector->getSelection())))) {
       BtnAddAll->activate();
       BtnRemAll->activate();
+      BtnSetAllRange->activate();
     } else {
       BtnAddAll->deactivate();
       BtnRemAll->deactivate();
+      BtnSetAllRange->deactivate();
     }
 
   } else {
@@ -3295,6 +3339,9 @@ void mainWindow_c::CreateProblemTab(void) {
     (new LFl_Box(xp++, 0))->setMinimumSize(SZ_GAP, 0);
     BtnRemAll = new LFlatButton_c(xp++, 0, 1, 1, "Clr", " Remove all pieces ", cb_RemoveAllShapesFromProblem_stub, this);
     ((LFlatButton_c*)BtnRemAll)->weight(1, 0);
+    (new LFl_Box(xp++, 0))->setMinimumSize(SZ_GAP, 0);
+    BtnSetAllRange = new LFlatButton_c(xp++, 0, 1, 1, "Set All", " Set min/max piece count for all shapes in the current problem ", cb_SetAllRange_stub, this);
+    ((LFlatButton_c*)BtnSetAllRange)->weight(1, 0);
     (new LFl_Box(xp++, 0))->setMinimumSize(SZ_GAP, 0);
     BtnGroup =    new LFlatButton_c(xp++, 0, 1, 1, "Detail", " Edit details of the problem ", cb_ShapeGroup_stub, this);
     ((LFlatButton_c*)BtnGroup)->weight(1, 0);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -809,11 +809,10 @@ void mainWindow_c::cb_SetAllRange(void) {
   if (newMin > newMax)
     newMax = newMin;
 
-  for (unsigned int i = 0; i < puzzle->getNumberOfShapes(); i++) {
-    if (pr->resultValid() && i == pr->getResultId())
-      continue;
-    pr->setShapeMaximum(i, newMax);
-    pr->setShapeMinimum(i, newMin);
+  for (unsigned int p = 0; p < pr->getNumberOfParts(); p++) {
+    unsigned int shapeId = pr->getShapeIdOfPart(p);
+    pr->setShapeMaximum(shapeId, newMax);
+    pr->setShapeMinimum(shapeId, newMin);
   }
 
   changed = true;

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -103,7 +103,7 @@ class mainWindow_c : public LFl_Double_Window {
   FlatButton *BtnNewColor, *BtnDelColor, *BtnChnColor;
   FlatButton *BtnNewProb, *BtnDelProb, *BtnCpyProb, *BtnRenProb, *BtnProbLeft, *BtnProbRight;
   FlatButton *BtnColSrtPc, *BtnColSrtRes, *BtnColAdd, *BtnColRem;
-  FlatButton *BtnSetResult, *BtnAddShape, *BtnRemShape, *BtnMinZero, *BtnAddAll, *BtnRemAll, *BtnGroup, *BtnProbShapeLeft, *BtnProbShapeRight;
+  FlatButton *BtnSetResult, *BtnAddShape, *BtnRemShape, *BtnMinZero, *BtnAddAll, *BtnRemAll, *BtnSetAllRange, *BtnGroup, *BtnProbShapeLeft, *BtnProbShapeRight;
 
   Fl_Progress *SolvingProgress;
   Fl_Value_Output *OutputAssemblies;
@@ -230,6 +230,7 @@ public:
   void cb_AddAllShapesToProblem(void);
   void cb_RemoveShapeFromProblem(void);
   void cb_RemoveAllShapesFromProblem(void);
+  void cb_SetAllRange(void);
   void cb_ProbShapeExchange(int with);
 
   void cb_PcSel(LBlockListGroup_c* reason);

--- a/src/gui/statuswindow.cpp
+++ b/src/gui/statuswindow.cpp
@@ -54,6 +54,7 @@ class LFl_Line : public Fl_Box, public layoutable_c {
 
 static void cb_Close_stub(Fl_Widget*, void* v) { ((statusWindow_c*)v)->hide(); }
 static void cb_RemoveSelected_stub(Fl_Widget*, void* v) { ((statusWindow_c*)v)->cb_removeSelected(); }
+static void cb_SelectHoles_stub(Fl_Widget*, void* v) { ((statusWindow_c*)v)->cb_selectHoles(); }
 
 class StatusProgress : public LFl_Double_Window {
 
@@ -114,6 +115,19 @@ void statusWindow_c::cb_removeSelected(void) {
 
   again = true;
   hide();
+}
+
+void statusWindow_c::cb_selectHoles(void) {
+
+  bt_assert(selection.size() <= puz->getNumberOfShapes());
+
+  for (unsigned int s = 0; s < selection.size(); s++) {
+    const voxel_c * v = puz->getShape(s);
+    bool has2DHoles = !v->connected(0, false, 0, false);
+    bool has3DHoles = !v->connected(0, false, 0);
+    if (has2DHoles || has3DHoles)
+      selection[s]->value(1);
+  }
 }
 
 statusWindow_c::statusWindow_c(puzzle_c * p) : LFl_Double_Window(true), puz(p), again(false) {
@@ -377,7 +391,13 @@ statusWindow_c::statusWindow_c(puzzle_c * p) : LFl_Double_Window(true), puz(p), 
 
   (new LFl_Box(1, 1))->setMinimumSize(5, 0);
 
-  btn = new LFl_Button("Remove selected", 2, 1);
+  btn = new LFl_Button("Select holes", 2, 1);
+  btn->callback(cb_SelectHoles_stub, this);
+  btn->weight(1, 0);
+
+  (new LFl_Box(3, 1))->setMinimumSize(5, 0);
+
+  btn = new LFl_Button("Remove selected", 4, 1);
   btn->callback(cb_RemoveSelected_stub, this);
   btn->weight(1, 0);
 

--- a/src/gui/statuswindow.cpp
+++ b/src/gui/statuswindow.cpp
@@ -55,6 +55,9 @@ class LFl_Line : public Fl_Box, public layoutable_c {
 static void cb_Close_stub(Fl_Widget*, void* v) { ((statusWindow_c*)v)->hide(); }
 static void cb_RemoveSelected_stub(Fl_Widget*, void* v) { ((statusWindow_c*)v)->cb_removeSelected(); }
 static void cb_SelectHoles_stub(Fl_Widget*, void* v) { ((statusWindow_c*)v)->cb_selectHoles(); }
+static void cb_SelectIdenticalShapes_stub(Fl_Widget*, void* v)   { ((statusWindow_c*)v)->cb_selectIdenticalShapes(); }
+static void cb_SelectIdenticalComplete_stub(Fl_Widget*, void* v) { ((statusWindow_c*)v)->cb_selectIdenticalComplete(); }
+static void cb_SelectIdenticalMirror_stub(Fl_Widget*, void* v)   { ((statusWindow_c*)v)->cb_selectIdenticalMirror(); }
 
 class StatusProgress : public LFl_Double_Window {
 
@@ -130,6 +133,27 @@ void statusWindow_c::cb_selectHoles(void) {
   }
 }
 
+void statusWindow_c::cb_selectIdenticalShapes(void) {
+
+  for (unsigned int s = 0; s < selection.size(); s++)
+    if (s < identicalShape.size() && identicalShape[s])
+      selection[s]->value(1);
+}
+
+void statusWindow_c::cb_selectIdenticalComplete(void) {
+
+  for (unsigned int s = 0; s < selection.size(); s++)
+    if (s < identicalComplete.size() && identicalComplete[s])
+      selection[s]->value(1);
+}
+
+void statusWindow_c::cb_selectIdenticalMirror(void) {
+
+  for (unsigned int s = 0; s < selection.size(); s++)
+    if (s < identicalMirror.size() && identicalMirror[s])
+      selection[s]->value(1);
+}
+
 statusWindow_c::statusWindow_c(puzzle_c * p) : LFl_Double_Window(true), puz(p), again(false) {
 
   StatusProgress *  stp = new StatusProgress;
@@ -202,6 +226,7 @@ statusWindow_c::statusWindow_c(puzzle_c * p) : LFl_Double_Window(true), puz(p), 
     unsigned int shapeIdx;
     unsigned char shapeTrans;
     bool shapeKnown = shapeTab.getSpace(v, &shapeIdx, &shapeTrans, voxelTable_c::PAR_MIRROR);
+    identicalMirror.push_back(shapeKnown);
 
     if (shapeKnown)
     {
@@ -216,6 +241,7 @@ statusWindow_c::statusWindow_c(puzzle_c * p) : LFl_Double_Window(true), puz(p), 
     Fl::wait(0);
 
     shapeKnown = shapeTab.getSpace(v, &shapeIdx, &shapeTrans, 0);
+    identicalShape.push_back(shapeKnown);
 
     if (shapeKnown)
     {
@@ -230,6 +256,7 @@ statusWindow_c::statusWindow_c(puzzle_c * p) : LFl_Double_Window(true), puz(p), 
     Fl::wait(0);
 
     shapeKnown = shapeTab.getSpace(v, &shapeIdx, &shapeTrans, voxelTable_c::PAR_COLOUR);
+    identicalComplete.push_back(shapeKnown && shapeTrans < p->getGridType()->getSymmetries()->getNumTransformations());
 
     if (shapeKnown && shapeTrans < p->getGridType()->getSymmetries()->getNumTransformations())
     {
@@ -399,6 +426,22 @@ statusWindow_c::statusWindow_c(puzzle_c * p) : LFl_Double_Window(true), puz(p), 
 
   btn = new LFl_Button("Remove selected", 4, 1);
   btn->callback(cb_RemoveSelected_stub, this);
+  btn->weight(1, 0);
+
+  btn = new LFl_Button("Select Identical Shapes", 0, 2);
+  btn->callback(cb_SelectIdenticalShapes_stub, this);
+  btn->weight(1, 0);
+
+  (new LFl_Box(1, 2))->setMinimumSize(5, 0);
+
+  btn = new LFl_Button("Select Identical Complete", 2, 2);
+  btn->callback(cb_SelectIdenticalComplete_stub, this);
+  btn->weight(1, 0);
+
+  (new LFl_Box(3, 2))->setMinimumSize(5, 0);
+
+  btn = new LFl_Button("Select Identical Mirror", 4, 2);
+  btn->callback(cb_SelectIdenticalMirror_stub, this);
   btn->weight(1, 0);
 
   fr->end();

--- a/src/gui/statuswindow.h
+++ b/src/gui/statuswindow.h
@@ -41,6 +41,7 @@ class statusWindow_c : public LFl_Double_Window {
     statusWindow_c(puzzle_c * p);
 
     void cb_removeSelected(void);
+    void cb_selectHoles(void);
 
     bool getAgain(void) { return again; }
 

--- a/src/gui/statuswindow.h
+++ b/src/gui/statuswindow.h
@@ -34,6 +34,9 @@ class statusWindow_c : public LFl_Double_Window {
     puzzle_c * puz;
 
     std::vector<LFl_Check_Button*> selection;
+    std::vector<bool> identicalMirror;
+    std::vector<bool> identicalShape;
+    std::vector<bool> identicalComplete;
     bool again;
 
   public:
@@ -42,6 +45,9 @@ class statusWindow_c : public LFl_Double_Window {
 
     void cb_removeSelected(void);
     void cb_selectHoles(void);
+    void cb_selectIdenticalShapes(void);
+    void cb_selectIdenticalComplete(void);
+    void cb_selectIdenticalMirror(void);
 
     bool getAgain(void) { return again; }
 


### PR DESCRIPTION
## Summary

Three related quality-of-life improvements to the Problems tab and the Shape Information dialog.

---

### 1 — Bulk piece range setter ("Set All" button)

A new **"Set All"** button in the Problems tab toolbar opens a small dialog where you enter a min and max count. Clicking **Apply to All** sets that min/max on every piece shape already added to the current problem (result shape excluded). Only shapes that are part of the problem are affected — shapes defined in the puzzle but not added to this problem are left untouched.

---

### 2 — "Select holes" button in Shape Information

In the **Shape Information** dialog (opened via the *Status* button), a new **"Select holes"** button automatically ticks the checkbox for every shape that has either 2-D holes or 3-D holes (i.e. the same condition that displays an ✗ in those columns). After clicking it you can immediately hit **Remove selected** to bulk-delete hollow shapes.

---

### 3 — "Select Identical" buttons in Shape Information

Three new buttons on a second row of the Shape Information dialog:

| Button | Selects shapes where… |
|---|---|
| **Select Identical Shapes** | the *Identical Shape* column is non-empty |
| **Select Identical Complete** | the *Identical Complete* column is non-empty |
| **Select Identical Mirror** | the *Identical Mirror* column is non-empty |

These let you quickly identify and remove duplicate shapes (by shape, orientation, or mirror) in bulk.

---

### Files changed

| File | Change |
|---|---|
| `src/gui/bulkrangewindow.h` | New dialog class `bulkRangeWindow_c` |
| `src/gui/bulkrangewindow.cpp` | New dialog implementation |
| `src/gui/statuswindow.h` | Added `identicalMirror/Shape/Complete` vectors + new callback declarations |
| `src/gui/statuswindow.cpp` | Added "Select holes" + three "Select Identical" callbacks and buttons |
| `src/gui/mainwindow.h` | `BtnSetAllRange` member + `cb_SetAllRange()` callback |
| `src/gui/mainwindow.cpp` | Button wiring, activation logic, `cb_SetAllRange()` implementation |
| `meson.build` | Added `bulkrangewindow.cpp` to `gui_src` |