### PR TITLE
Speed up assembler preparation and placement reduction

### DIFF
--- a/src/lib/assembler.cpp
+++ b/src/lib/assembler.cpp
@@ -20,7 +20,196 @@
  */
 #include "assembler.h"
 
+#include "problem.h"
+#include "puzzle.h"
+#include "voxel.h"
+
 #include "../tools/xml.h"
+
+#include <algorithm>
+
+placementFinder_c::placementFinder_c(const problem_c & problem, const voxel_c * result) :
+  prob(problem), res(result)
+{
+  colorTableWidth = problem.getPuzzle().colorNumber() + 1;
+
+  if (colorTableWidth > 1) {
+    colorAllowed.resize(colorTableWidth * colorTableWidth);
+    for (unsigned int p = 0; p < colorTableWidth; p++)
+      for (unsigned int r = 0; r < colorTableWidth; r++)
+        colorAllowed[p * colorTableWidth + r] = problem.placementAllowed(p, r) ? 1 : 0;
+  }
+
+  /* all non empty voxels of the result, these are the only voxels a filled
+   * piece voxel may end up on, so they are the only candidate positions for
+   * the anchor voxel of a piece
+   */
+  unsigned int idx = 0;
+  for (unsigned int z = 0; z < result->getZ(); z++)
+    for (unsigned int y = 0; y < result->getY(); y++)
+      for (unsigned int x = 0; x < result->getX(); x++, idx++)
+        if (result->getState(idx) != voxel_c::VX_EMPTY) {
+          resultVoxel_s e;
+          e.x = x;
+          e.y = y;
+          e.z = z;
+          e.index = idx;
+          e.color = result->getColor(idx);
+          resultVoxels.push_back(e);
+        }
+}
+
+void placementFinder_c::find(const voxel_c * rotation,
+    std::vector<long> & voxelOffsets,
+    std::vector<int> & placements) const
+{
+  voxelOffsets.clear();
+  placements.clear();
+
+  /* the placement window: the same translations the brute force scan tried,
+   * the bounding box of the piece stays within the bounding box of the result
+   */
+  const int wx1 = (int)res->boundX1()-(int)rotation->boundX1();
+  const int wx2 = (int)res->boundX2()-(int)rotation->boundX2();
+  const int wy1 = (int)res->boundY1()-(int)rotation->boundY1();
+  const int wy2 = (int)res->boundY2()-(int)rotation->boundY2();
+  const int wz1 = (int)res->boundZ1()-(int)rotation->boundZ1();
+  const int wz2 = (int)res->boundZ2()-(int)rotation->boundZ2();
+
+  if ((wx2 < wx1) || (wy2 < wy1) || (wz2 < wz1))
+    return;
+
+  const long sx = res->getX();
+  const long sy = res->getY();
+
+  /* the filled voxels of the piece as result space index offsets relative to
+   * the translation, in the order the matrix nodes are emitted
+   */
+  std::vector<unsigned char> voxelColor;
+  std::vector<long> checkOffsets;         // colour-only checks for cells that are not filled
+  std::vector<unsigned char> checkColor;
+
+  /* the anchor is the first filled voxel of the piece. Note that its
+   * coordinates can not be recovered from its index offset because the piece
+   * voxel space may be bigger than the result voxel space, so they are
+   * recorded here directly */
+  int ax = 0, ay = 0, az = 0;
+
+  for (unsigned int pz = rotation->boundZ1(); pz <= rotation->boundZ2(); pz++)
+    for (unsigned int py = rotation->boundY1(); py <= rotation->boundY2(); py++)
+      for (unsigned int px = rotation->boundX1(); px <= rotation->boundX2(); px++) {
+        if (rotation->getState(px, py, pz) == voxel_c::VX_FILLED) {
+          if (voxelOffsets.empty()) {
+            ax = px;
+            ay = py;
+            az = pz;
+          }
+          voxelOffsets.push_back(px + sx * (py + sy * pz));
+          voxelColor.push_back(rotation->getColor(px, py, pz));
+        } else if ((colorTableWidth > 1) && (rotation->getColor(px, py, pz) != 0)) {
+          /* a coloured cell that is not filled can not occupy a result voxel
+           * but it still takes part in the colour constraint check */
+          checkOffsets.push_back(px + sx * (py + sy * pz));
+          checkColor.push_back(rotation->getColor(px, py, pz));
+        }
+      }
+
+  if (voxelOffsets.empty())
+    return;
+
+  const long anchorOff = voxelOffsets[0];
+
+  const unsigned int voxels = voxelOffsets.size();
+  const unsigned int checks = checkOffsets.size();
+
+  /* checks whether the piece fits at the translation with the given result
+   * space base index, the state of the anchor voxel has already been tested
+   * by the caller */
+  auto fits = [&](long base, unsigned char anchorResColor) -> bool {
+
+    if (colorTableWidth > 1 && !colorAllowed[voxelColor[0] * colorTableWidth + anchorResColor])
+      return false;
+
+    for (unsigned int v = 1; v < voxels; v++) {
+      const unsigned int ri = base + voxelOffsets[v];
+      if (res->getState(ri) == voxel_c::VX_EMPTY)
+        return false;
+      if (colorTableWidth > 1 && !colorAllowed[voxelColor[v] * colorTableWidth + res->getColor(ri)])
+        return false;
+    }
+
+    for (unsigned int c = 0; c < checks; c++)
+      if (!colorAllowed[checkColor[c] * colorTableWidth + res->getColor(base + checkOffsets[c])])
+        return false;
+
+    return true;
+  };
+
+  const unsigned long windowVol =
+    (unsigned long)(wx2-wx1+1) * (wy2-wy1+1) * (wz2-wz1+1);
+
+  if (resultVoxels.size() < windowVol) {
+
+    /* the result is sparse within its bounding box: only try translations
+     * that put the anchor onto one of the non empty result voxels */
+    for (unsigned int i = 0; i < resultVoxels.size(); i++) {
+
+      const resultVoxel_s & rv = resultVoxels[i];
+
+      const int x = rv.x - ax;
+      const int y = rv.y - ay;
+      const int z = rv.z - az;
+
+      if ((x < wx1) || (x > wx2) || (y < wy1) || (y > wy2) || (z < wz1) || (z > wz2))
+        continue;
+
+      if (!rotation->onGrid(x, y, z))
+        continue;
+
+      if (fits(rv.index - anchorOff, rv.color)) {
+        placements.push_back(x);
+        placements.push_back(y);
+        placements.push_back(z);
+      }
+    }
+
+    /* the result voxels are traversed x fastest, the brute force scan tried x
+     * slowest, restore that order so the matrix is built up identically
+     */
+    struct triple_s { int x, y, z; };
+    triple_s * t = (triple_s*)placements.data();
+    std::sort(t, t + placements.size()/3, [](const triple_s & a, const triple_s & b) {
+        if (a.x != b.x) return a.x < b.x;
+        if (a.y != b.y) return a.y < b.y;
+        return a.z < b.z;
+        });
+
+  } else {
+
+    /* the result is mostly filled: iterating the translation window directly
+     * is cheaper than going through the voxel list and needs no sorting, the
+     * anchor voxel read rejects most translations with a single access */
+    for (int x = wx1; x <= wx2; x++)
+      for (int y = wy1; y <= wy2; y++)
+        for (int z = wz1; z <= wz2; z++) {
+
+          const long base = x + sx * (y + sy * (long)z);
+          const long ri = base + anchorOff;
+
+          if (res->getState(ri) == voxel_c::VX_EMPTY)
+            continue;
+
+          if (!rotation->onGrid(x, y, z))
+            continue;
+
+          if (fits(base, res->getColor(ri))) {
+            placements.push_back(x);
+            placements.push_back(y);
+            placements.push_back(z);
+          }
+        }
+  }
+}
 
 assembler_c::errState assembler_c::createMatrix(bool /*keepMirror*/, bool /*keepRotations*/, bool /*complete*/)
 {

--- a/src/lib/assembler.h
+++ b/src/lib/assembler.h
@@ -25,10 +25,63 @@
  * contains the classes used for the assembler
  */
 
+#include <vector>
+
 class voxel_c;
 class assembly_c;
 class problem_c;
 class xmlWriter_c;
+
+/**
+ * Helper for the assembler preparation step: enumerates all placements of a
+ * rotated piece inside the result shape.
+ *
+ * Instead of trying every translation of the piece bounding box inside the
+ * result bounding box and rescanning the whole piece for each of them, only
+ * translations that put the first filled voxel of the piece (the anchor) onto
+ * a non empty result voxel are candidates. All other translations can not
+ * result in a valid placement. The remaining voxels are then verified with
+ * single indexed reads. For results or grids where the bounding box is much
+ * bigger than the number of usable voxels this removes a factor proportional
+ * to the bounding box volume / non empty voxel ratio.
+ */
+class placementFinder_c {
+
+public:
+
+  placementFinder_c(const problem_c & problem, const voxel_c * result);
+
+  /**
+   * find all placements of the given rotated piece.
+   *
+   * voxelOffsets receives, for each filled voxel of the piece (in the order
+   * the matrix nodes must be emitted), the result space index offset relative
+   * to a placement, so that resultindex = x + sx*(y + sy*z) + voxelOffsets[i].
+   *
+   * placements receives packed (x, y, z) translation triples of all valid
+   * placements, ordered x, then y, then z ascending, exactly like the
+   * original brute force scan produced them.
+   */
+  void find(const voxel_c * rotation,
+      std::vector<long> & voxelOffsets,
+      std::vector<int> & placements) const;
+
+private:
+
+  typedef struct {
+    int x, y, z;          ///< coordinates of the voxel
+    unsigned long index;  ///< index within the result voxel space
+    unsigned char color;  ///< colour of the result voxel
+  } resultVoxel_s;
+
+  const problem_c & prob;
+  const voxel_c * res;
+
+  std::vector<resultVoxel_s> resultVoxels;  ///< all non empty voxels of the result
+
+  unsigned int colorTableWidth;             ///< number of colours + 1
+  std::vector<unsigned char> colorAllowed;  ///< placementAllowed lookup table
+};
 
 /**
  * The callback class used to return found assemblies to the caller

--- a/src/lib/assembler_0.cpp
+++ b/src/lib/assembler_0.cpp
@@ -31,6 +31,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <unordered_map>
 
 #ifdef _WIN32
 #define snprintf _snprintf
@@ -240,72 +241,94 @@ void assembler_0_c::getPieceInformation(unsigned int node, unsigned char *tran, 
  */
 unsigned int assembler_0_c::clumpify(void) {
 
-  unsigned int col = right[0];
-  unsigned int removed = 0;
+  /* two columns are identical, and one of them can be removed, when they
+   * are contained in exactly the same placement rows.
+   *
+   * instead of comparing all pairs of columns we compute a signature for
+   * each column (the sequence of placement rows, the down links enumerate
+   * the nodes in row order because rows are appended in increasing order)
+   * and group the columns by a hash of that signature. Only columns within
+   * the same group are then compared exactly. This is linear in the number
+   * of matrix nodes while the pairwise comparison was quadratic in the
+   * number of columns
+   */
 
-  while (col) {
+  /* the columns in header ring order, the first column of each group of
+   * identical columns is the one that survives, like before */
+  std::vector<unsigned int> cols;
+  for (unsigned int c = right[0]; c; c = right[c])
+    cols.push_back(c);
 
-    /* find all columns that are identical to col
-     */
+  /* all signatures are stored back to back in one vector, per column we
+   * keep the start of its signature within that vector */
+  std::vector<unsigned long> sigData;
+  std::vector<unsigned long> sigStart;
+  std::vector<unsigned long long> sigHash;
 
-    /* this vector will contain all the columns that are not
-     * yet ruled out to be different from col
-     * the vector contains the node index
-     */
-    std::vector<unsigned int>columns;
+  sigStart.reserve(cols.size()+1);
+  sigHash.reserve(cols.size());
 
-    unsigned int c = right[col];
+  for (unsigned int i = 0; i < cols.size(); i++) {
 
-    while (c) {
-      columns.push_back(down(c));
-      c = right[c];
-    }
+    const unsigned int col = cols[i];
 
-    unsigned int row = down(col);
+    sigStart.push_back(sigData.size());
+
+    unsigned long long h = 14695981039346656037ull;
+
     unsigned int line = 0;
 
-    while (row != col) {
+    for (unsigned int row = down(col); row != col; row = down(row)) {
 
-      while ((line < piecePositions.size()) && (piecePositions[line+1].row <= row)) line++;
+      /* find the placement row this node belongs to, the nodes come in
+       * increasing order so the line only ever advances */
+      while ((line+1 < piecePositions.size()) && (piecePositions[line+1].row <= row))
+        line++;
 
-      unsigned int i = 0;
+      sigData.push_back(line);
 
-      /* remove all columns that are not in the same
-       * line as the column
-       */
-      while (i < columns.size()) {
-        if ((columns[i] < piecePositions[line].row) ||
-            (columns[i] >= piecePositions[line+1].row)
-           ) {
-          columns.erase(columns.begin()+i);
-        } else
-          i++;
-      }
+      h = (h ^ line) * 1099511628211ull;
+    }
 
-      if (columns.size() == 0)
+    sigHash.push_back(h);
+  }
+
+  sigStart.push_back(sigData.size());
+
+  /* group by hash, keep the first column of each group, exactly verify
+   * the others against it before removing them */
+  typedef std::unordered_map<unsigned long long, std::vector<unsigned int> > hashMap;
+  hashMap groups;
+
+  unsigned int removed = 0;
+
+  for (unsigned int i = 0; i < cols.size(); i++) {
+
+    std::vector<unsigned int> & group = groups[sigHash[i]];
+
+    bool dup = false;
+
+    for (unsigned int g = 0; g < group.size(); g++) {
+
+      const unsigned int j = group[g];
+
+      const unsigned long leni = sigStart[i+1]-sigStart[i];
+
+      if (leni != sigStart[j+1]-sigStart[j])
+        continue;
+
+      if ((leni == 0) ||
+          (memcmp(&sigData[sigStart[i]], &sigData[sigStart[j]], leni * sizeof(unsigned long)) == 0)) {
+        dup = true;
         break;
-
-      row = down(row);
-
-      for (i = 0; i < columns.size(); i++)
-        columns[i] = down(columns[i]);
+      }
     }
 
-    /* now all the columns need to be in the header again */
-    unsigned int i = 0;
-    while (i < columns.size()) {
-      if (columns[i] >= piecePositions[0].row)
-        columns.erase(columns.begin()+i);
-      else
-        i++;
-    }
-
-    for (unsigned int i = 0; i < columns.size(); i++)
-      remove_column(columns[i]);
-
-    removed += columns.size();
-
-    col = right[col];
+    if (dup) {
+      remove_column(cols[i]);
+      removed++;
+    } else
+      group.push_back(i);
   }
 
   return removed;
@@ -600,6 +623,13 @@ int assembler_0_c::prepare(void) {
 
   voxel_c ** cache = new voxel_c *[sym->getNumTransformationsMirror()];
 
+  placementFinder_c finder(problem, result);
+  std::vector<long> voxelOffsets;
+  std::vector<int> positions;
+
+  const long rsx = result->getX();
+  const long rsy = result->getY();
+
   /* now we insert one shape after another */
   for (unsigned int pc = 0; pc < problem.getNumberOfParts(); pc++) {
 
@@ -625,22 +655,22 @@ int assembler_0_c::prepare(void) {
       rotation = addToCache(cache, &cachefill, rotation);
 
       if (rotation) {
-        for (int x = (int)result->boundX1()-(int)rotation->boundX1(); x <= (int)result->boundX2()-(int)rotation->boundX2(); x++)
-          for (int y = (int)result->boundY1()-(int)rotation->boundY1(); y <= (int)result->boundY2()-(int)rotation->boundY2(); y++)
-            for (int z = (int)result->boundZ1()-(int)rotation->boundZ1(); z <= (int)result->boundZ2()-(int)rotation->boundZ2(); z++)
-              if (canPlace(rotation, x, y, z)) {
+        finder.find(rotation, voxelOffsets, positions);
 
-                int piecenode = AddPieceNode(pc, rot, x+rotation->getHx(), y+rotation->getHy(), z+rotation->getHz());
-                placements = 1;
+        for (unsigned int pos = 0; pos < positions.size(); pos += 3) {
 
-                /* now add the used cubes of the piece */
-                for (unsigned int pz = rotation->boundZ1(); pz <= rotation->boundZ2(); pz++)
-                  for (unsigned int py = rotation->boundY1(); py <= rotation->boundY2(); py++)
-                    for (unsigned int px = rotation->boundX1(); px <= rotation->boundX2(); px++)
-                      if (rotation->getState(px, py, pz) == voxel_c::VX_FILLED)
-                        AddVoxelNode(columns[result->getIndex(x+px, y+py, z+pz)], piecenode);
-              }
+          const int x = positions[pos];
+          const int y = positions[pos+1];
+          const int z = positions[pos+2];
 
+          int piecenode = AddPieceNode(pc, rot, x+rotation->getHx(), y+rotation->getHy(), z+rotation->getHz());
+          placements = 1;
+
+          /* now add the used cubes of the piece */
+          const long base = x + rsx * (y + rsy * (long)z);
+          for (unsigned int v = 0; v < voxelOffsets.size(); v++)
+            AddVoxelNode(columns[base + voxelOffsets[v]], piecenode);
+        }
 
         /* for the symmetry breaker piece we also add all symmetries of the box */
         if (pc == symBreakerShape)

--- a/src/lib/assembler_1.cpp
+++ b/src/lib/assembler_1.cpp
@@ -30,6 +30,8 @@
 #include "../tools/xml.h"
 
 #include <cstdlib>
+#include <cstring>
+#include <unordered_map>
 
 #ifdef _WIN32
 #define snprintf _snprintf
@@ -567,6 +569,13 @@ int assembler_1_c::prepare(bool hasRange, unsigned int rangeMin, unsigned int ra
 
   voxel_c ** cache = new voxel_c *[sym->getNumTransformationsMirror()];
 
+  placementFinder_c finder(problem, result);
+  std::vector<long> voxelOffsets;
+  std::vector<int> positions;
+
+  const long rsx = result->getX();
+  const long rsy = result->getY();
+
   /* now we insert one shape after another */
   for (unsigned int pc = 0; pc < problem.getNumberOfParts(); pc++) {
 
@@ -599,27 +608,27 @@ int assembler_1_c::prepare(bool hasRange, unsigned int rangeMin, unsigned int ra
       rotation = addToCache(cache, &cachefill, rotation);
 
       if (rotation) {
-        for (int x = (int)result->boundX1()-(int)rotation->boundX1(); x <= (int)result->boundX2()-(int)rotation->boundX2(); x++)
-          for (int y = (int)result->boundY1()-(int)rotation->boundY1(); y <= (int)result->boundY2()-(int)rotation->boundY2(); y++)
-            for (int z = (int)result->boundZ1()-(int)rotation->boundZ1(); z <= (int)result->boundZ2()-(int)rotation->boundZ2(); z++)
-              if (canPlace(rotation, x, y, z)) {
+        finder.find(rotation, voxelOffsets, positions);
 
-                int piecenode = AddPieceNode(pc, rot, x+rotation->getHx(), y+rotation->getHy(), z+rotation->getHz());
-                placements++;
+        for (unsigned int pos = 0; pos < positions.size(); pos += 3) {
 
-                /* now add the used cubes of the piece */
-                for (unsigned int pz = rotation->boundZ1(); pz <= rotation->boundZ2(); pz++)
-                  for (unsigned int py = rotation->boundY1(); py <= rotation->boundY2(); py++)
-                    for (unsigned int px = rotation->boundX1(); px <= rotation->boundX2(); px++)
-                      if (rotation->getState(px, py, pz) == voxel_c::VX_FILLED) {
-                        AddVoxelNode(columns[result->getIndex(x+px, y+py, z+pz)], piecenode);
-                      }
+          const int x = positions[pos];
+          const int y = positions[pos+1];
+          const int z = positions[pos+2];
 
-                // if we use the range counting and the piece is using a range, add it to
-                // the column
-                if (hasRange && (min[pc+1] != max[pc+1]))
-                  AddRangeNode(rangeColumn, piecenode, voxels);
-              }
+          int piecenode = AddPieceNode(pc, rot, x+rotation->getHx(), y+rotation->getHy(), z+rotation->getHz());
+          placements++;
+
+          /* now add the used cubes of the piece */
+          const long base = x + rsx * (y + rsy * (long)z);
+          for (unsigned int v = 0; v < voxelOffsets.size(); v++)
+            AddVoxelNode(columns[base + voxelOffsets[v]], piecenode);
+
+          // if we use the range counting and the piece is using a range, add it to
+          // the column
+          if (hasRange && (min[pc+1] != max[pc+1]))
+            AddRangeNode(rangeColumn, piecenode, voxels);
+        }
         /* for the symmetry breaker piece we also add all symmetries of the box */
         if (pc == symBreakerShape)
           for (unsigned int r = 1; r < sym->getNumTransformations(); r++)
@@ -765,75 +774,102 @@ void assembler_1_c::remove_column(unsigned int c) {
  */
 unsigned int assembler_1_c::clumpify(void) {
 
-  unsigned int col = right[0];
-  unsigned int removed = 0;
+  /* two columns are identical, and one of them can be removed, when they
+   * have the same min and max values and are contained in exactly the same
+   * placement rows with the same node weights.
+   *
+   * instead of comparing all pairs of columns we compute a signature for
+   * each column (the sequence of (placement row, node weight) pairs, the
+   * down links enumerate the nodes in row order because rows are appended
+   * in increasing order) and group the columns by a hash of that signature.
+   * only columns within the same group are then compared exactly. This
+   * is linear in the number of matrix nodes while the pairwise comparison
+   * was quadratic in the number of columns
+   */
 
-  while (col) {
+  /* the columns in header ring order, the first column of each group of
+   * identical columns is the one that survives, like before */
+  std::vector<unsigned int> cols;
+  for (unsigned int c = right[0]; c; c = right[c])
+    cols.push_back(c);
 
-    /* find all columns that are identical to col
-     */
+  /* all signatures are stored back to back in one vector, per column we
+   * keep the start of its signature within that vector */
+  std::vector<unsigned long> sigData;
+  std::vector<unsigned long> sigStart;
+  std::vector<unsigned long long> sigHash;
 
-    /* this vector will contain all the columns that are not
-     * yet ruled out to be different from col
-     * the vector contains the node index
-     */
-    std::vector<unsigned int>columns;
+  sigStart.reserve(cols.size()+1);
+  sigHash.reserve(cols.size());
 
-    unsigned int c = right[col];
+  for (unsigned int i = 0; i < cols.size(); i++) {
 
-    while (c) {
-      if (min[c] == min[col] && max[c] == max[col])
-        columns.push_back(down[c]);
-      c = right[c];
-    }
+    const unsigned int col = cols[i];
 
-    unsigned int row = down[col];
+    sigStart.push_back(sigData.size());
+
+    unsigned long long h = 14695981039346656037ull;
+    h = (h ^ min[col]) * 1099511628211ull;
+    h = (h ^ max[col]) * 1099511628211ull;
+
     unsigned int line = 0;
 
-    while (row != col) {
+    for (unsigned int row = down[col]; row != col; row = down[row]) {
 
+      /* find the placement row this node belongs to, the nodes come in
+       * increasing order so the line only ever advances */
       while ((line+1 < piecePositions.size()) && (piecePositions[line+1].row <= row))
         line++;
 
-      unsigned int i = 0;
+      sigData.push_back(line);
+      sigData.push_back(weight[row]);
 
-      /* remove all columns that are not in the same
-       * line as the column
-       */
-      while (i < columns.size()) {
-        if ((columns[i] < piecePositions[line].row) ||
-            ((line+1 < piecePositions.size()) && (columns[i] >= piecePositions[line+1].row)) ||
-            (weight[row] != weight[columns[i]])  // also remove row, if weights differ
-           ) {
-          columns.erase(columns.begin()+i);
-        } else
-          i++;
-      }
+      h = (h ^ line) * 1099511628211ull;
+      h = (h ^ (unsigned long long)weight[row]) * 1099511628211ull;
+    }
 
-      if (columns.size() == 0)
+    sigHash.push_back(h);
+  }
+
+  sigStart.push_back(sigData.size());
+
+  /* group by hash, keep the first column of each group, exactly verify
+   * the others against it before removing them */
+  typedef std::unordered_map<unsigned long long, std::vector<unsigned int> > hashMap;
+  hashMap groups;
+
+  unsigned int removed = 0;
+
+  for (unsigned int i = 0; i < cols.size(); i++) {
+
+    std::vector<unsigned int> & group = groups[sigHash[i]];
+
+    bool dup = false;
+
+    for (unsigned int g = 0; g < group.size(); g++) {
+
+      const unsigned int j = group[g];
+
+      if (min[cols[i]] != min[cols[j]] || max[cols[i]] != max[cols[j]])
+        continue;
+
+      const unsigned long leni = sigStart[i+1]-sigStart[i];
+
+      if (leni != sigStart[j+1]-sigStart[j])
+        continue;
+
+      if ((leni == 0) ||
+          (memcmp(&sigData[sigStart[i]], &sigData[sigStart[j]], leni * sizeof(unsigned long)) == 0)) {
+        dup = true;
         break;
-
-      row = down[row];
-
-      for (i = 0; i < columns.size(); i++)
-        columns[i] = down[columns[i]];
+      }
     }
 
-    /* now all the columns need to be in the header again */
-    unsigned int i = 0;
-    while (i < columns.size()) {
-      if (columns[i] >= piecePositions[0].row)
-        columns.erase(columns.begin()+i);
-      else
-        i++;
-    }
-
-    for (unsigned int i = 0; i < columns.size(); i++)
-      remove_column(columns[i]);
-
-    removed += columns.size();
-
-    col = right[col];
+    if (dup) {
+      remove_column(cols[i]);
+      removed++;
+    } else
+      group.push_back(i);
   }
 
   return removed;


### PR DESCRIPTION
Two algorithmic fixes to the solver preprocessing, motivated by a rhombic-grid packing puzzle (21^3 conceptual cube = 105^3 voxel space, one 37k-voxel piece) on which the "reduce placements" step effectively never terminated.

## 1. Placement enumeration (`prepare`)

The old code tried every translation of the piece bounding box inside the result bounding box and rescanned the whole piece bounding box per candidate via `canPlace()` — O(rotations × result_bbox × piece_bbox), where the slack versus actual output becomes an extra polynomial factor whenever the result or the grid is sparse in its bounding box (hollow shapes; triangular/rhombic/tetra-octa grids, whose storage representation is mostly padding).

The new `placementFinder_c` (shared by both assemblers) enumerates, per rotation, only translations that put the piece's first filled voxel (the *anchor*) onto a non-empty result voxel — or, when the result is dense in its bbox, sweeps the translation window rejecting most positions with a single indexed anchor read. Remaining voxels are verified through precomputed result-index offsets with early exit; colour constraints use a precomputed lookup table instead of a `std::set` search per voxel pair; matrix node emission iterates only filled voxels. Placements are emitted in the exact order of the old scan, so **the matrix is built bit-identically**.

## 2. `clumpify()` (duplicate-column merge in `reduce`)

The old implementation compared each column against all columns to its right, pruning a candidate vector with mid-vector `erase()` — effectively quadratic in the number of columns, with each erase paying a memmove of the vector tail. On the motivating puzzle (222k columns), a profiler showed 100% of reduce time inside that memmove; estimated completion was measured in weeks.

The new implementation hashes each column's signature — its ordered list of (placement row, node weight) memberships plus min/max — groups columns by hash, and exactly verifies only within groups. Linear in the number of matrix nodes. The earliest column in ring order survives each group, as before.

## Results

| case | before | after |
|---|---|---|
| motivating puzzle, prepare | 349 ms | 148 ms |
| motivating puzzle, reduce | does not terminate (est. weeks) | **5.0 s** |
| motivating puzzle, full solve with `-r` | — | 2.9 s |
| HexSticks example, prepare | 5.7 ms | 2.0 ms |
| hollow-shell benchmark 128³, prepare | 64 ms | 52 ms |
| dense 28³ box packing, prepare | 54 ms | 55 ms (parity) |

(Times with `-Db_ndebug=true` builds for both sides.)

## Verification

* An exhaustive checker compared brute-force `canPlace` enumeration against `placementFinder_c` for every part × transformation × problem of all 18 shipped example puzzles plus synthetic box/shell/tray puzzles — identical placement sets across all grid types, including colour-constrained puzzles and multi-problem files.
* Full solves (`burrTxt -q` and `burrTxt -r -q`) of the example puzzles produce identical row/column removal counts, assembly counts and solver iteration counts before and after — iteration-count equality implies the DLX matrix is identical node for node.

🤖 Generated with [Claude Code](https://claude.com/claude-code)