### PR TITLE
Fix heap corruption when loading malformed puzzle files

### DIFF
--- a/src/lib/solution.cpp
+++ b/src/lib/solution.cpp
@@ -29,7 +29,7 @@
 #include <stdlib.h>
 
 solution_c::solution_c(xmlParser_c & pars, unsigned int pieces, const gridType_c * gt) :
-  tree(0), treeInfo(0), assemblyNum(0), solutionNum(0)
+  assembly(0), tree(0), treeInfo(0), assemblyNum(0), solutionNum(0)
 {
   pars.require(xmlParser_c::START_TAG, "solution");
 

--- a/src/lib/voxel.cpp
+++ b/src/lib/voxel.cpp
@@ -805,8 +805,21 @@ voxel_c::voxel_c(xmlParser_c & pars, const gridType_c * g) : gt(g), hx(0), hy(0)
 
   unsigned int type = atoi(szStr.c_str());
 
+  // validate the dimensions before computing the size: the attributes come
+  // from an untrusted file and atoi of a negative or huge value wraps into a
+  // large unsigned int. Without this check sx*sy*sz can overflow the 32 bit
+  // voxels field, producing an allocation far too small for the coordinates
+  // that follow (getIndex = x + sx*(y + sy*z)), i.e. heap corruption.
+  if (sx > 0x10000 || sy > 0x10000 || sz > 0x10000)
+    pars.exception("voxel space dimension too large");
+
+  // the per axis limit keeps this product well within 64 bits
+  unsigned long long vox64 = (unsigned long long)sx * sy * sz;
+  if (vox64 > 0x40000000ull)
+    pars.exception("voxel space too large");
+
   // set to the correct size
-  voxels = sx*sy*sz;
+  voxels = (unsigned int)vox64;
 
   szStr = pars.getAttributeValue("hx");
   hx = atoi(szStr.c_str());
@@ -841,14 +854,20 @@ voxel_c::voxel_c(xmlParser_c & pars, const gridType_c * g) : gt(g), hx(0), hy(0)
       switch (c[pos])
       {
         case '#':
+          if (idx >= getXYZ())
+            pars.exception("too many voxels defined for voxelspace");
           setState(idx++, VX_FILLED);
           color = 0;
           break;
         case '+':
+          if (idx >= getXYZ())
+            pars.exception("too many voxels defined for voxelspace");
           setState(idx++, VX_VARIABLE);
           color = 0;
           break;
         case '_':
+          if (idx >= getXYZ())
+            pars.exception("too many voxels defined for voxelspace");
           setState(idx++, VX_EMPTY);
           color = 0;
           break;
@@ -870,9 +889,6 @@ voxel_c::voxel_c(xmlParser_c & pars, const gridType_c * g) : gt(g), hx(0), hy(0)
 
       if (idx > 0)
         setColor(idx-1, color);
-
-      if (idx > getXYZ())
-        pars.exception("too many voxels defined for voxelspace");
     }
     if (idx < getXYZ())
       pars.exception("not enough voxels defined for voxelspace");

--- a/test/malformed/README.md
+++ b/test/malformed/README.md
@@ -1,0 +1,22 @@
+# Malformed-input regression fixtures
+
+Each file here is a crafted `.xmpuzzle` that triggered a memory-safety bug in the
+loader before the accompanying fix. In a release build (`-Db_ndebug=true`) the
+`bt_assert` bounds checks are compiled out, so these produced real out-of-bounds
+accesses rather than clean exceptions. After the fix each one is rejected with a
+parser exception.
+
+| file | bug | fix |
+|------|-----|-----|
+| `too_many_voxels.xmpuzzle` | voxel content had one more state char than the space holds; `setState(idx++)` wrote out of bounds *before* the count check | bounds-check moved ahead of the write in `voxel.cpp` |
+| `oversized_dimensions.xmpuzzle` | `x*y*z` overflowed the 32-bit size field, under-allocating the space | dimensions validated before the multiply in `voxel.cpp` |
+| `separation_before_assembly.xmpuzzle` | a `<solution>` whose `<separation>` preceded its `<assembly>` dereferenced an uninitialized `assembly` pointer | `assembly` initialized to 0 in `solution.cpp` |
+
+Reproduce (release-like sanitizer build):
+
+    meson setup build-asan --buildtype=debugoptimized -Db_sanitize=address,undefined -Db_ndebug=true
+    ninja -C build-asan burrTxt
+    ./build-asan/burrTxt -q test/malformed/too_many_voxels.xmpuzzle
+
+Expected after the fix: an `xmlParserException_c` (e.g. "too many voxels defined
+for voxelspace"), and no AddressSanitizer report.

--- a/test/malformed/oversized_dimensions.xmpuzzle
+++ b/test/malformed/oversized_dimensions.xmpuzzle
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<puzzle version="2">
+ <gridType type="0"/>
+ <colors/>
+ <shapes>
+  <voxel x="65536" y="65536" z="1" type="0">_</voxel>
+ </shapes>
+ <problems/>
+ <comment/>
+</puzzle>

--- a/test/malformed/separation_before_assembly.xmpuzzle
+++ b/test/malformed/separation_before_assembly.xmpuzzle
@@ -1,0 +1,93 @@
+<?xml version="1.0"?>
+<puzzle version="2">
+ <gridType type="0"/>
+ <colors/>
+ <shapes>
+  <voxel x="7" y="7" z="7" type="0">________#####__#####__#####__#####__#####_________#####_#+++++##+++++##+++++##+++++##+++++#_#####__#####_#+++++##+++++##+++++##+++++##+++++#_#####__#####_#+++++##+++++##+++++##+++++##+++++#_#####__#####_#+++++##+++++##+++++##+++++##+++++#_#####__#####_#+++++##+++++##+++++##+++++##+++++#_#####_________#####__#####__#####__#####__#####________</voxel>
+  <voxel x="5" y="5" z="6" type="0">#########################_____#####_____#____#_#_______###__#____#____#_#_________#______________#_________#______________#________________________#__</voxel>
+  <voxel x="5" y="5" z="6" type="0">#########################_____#####_________#__#_#_______###____#____#__#_#_______#______________#_________#______________#________________________#__</voxel>
+  <voxel x="5" y="5" z="6" type="0">#########################_____#####_____#____#_#_______###_______#____#_#_________#______________#_________#______________#________________________#__</voxel>
+ </shapes>
+ <problems>
+  <problem state="2" assemblies="1" solutions="1" time="0">
+   <shapes>
+    <shape id="1" count="2"/>
+    <shape id="3" count="1"/>
+    <shape id="2" count="3"/>
+   </shapes>
+   <result id="0"/>
+   <bitmap/>
+   <solutions>
+    <solution>
+     <separation>
+      <pieces count="6">0 1 2 3 4 5</pieces>
+      <state>
+       <dx>5 6 1 1 1 0</dx>
+       <dy>0 5 1 5 6 5</dy>
+       <dz>5 1 0 6 5 5</dz>
+      </state>
+      <state>
+       <dx>5 6 1 1 1 0</dx>
+       <dy>0 5 1 5 6 5</dy>
+       <dz>5 1 -20000 6 5 5</dz>
+      </state>
+      <separation type="left">
+       <pieces count="5">0 1 3 4 5</pieces>
+       <state>
+        <dx>5 6 1 1 0</dx>
+        <dy>0 5 5 6 5</dy>
+        <dz>5 1 6 5 5</dz>
+       </state>
+       <state>
+        <dx>5 6 1 1 0</dx>
+        <dy>0 5 5 20006 5</dy>
+        <dz>5 1 6 5 5</dz>
+       </state>
+       <separation type="left">
+        <pieces count="4">0 1 3 5</pieces>
+        <state>
+         <dx>5 6 1 0</dx>
+         <dy>0 5 5 5</dy>
+         <dz>5 1 6 5</dz>
+        </state>
+        <state>
+         <dx>5 20006 1 0</dx>
+         <dy>0 5 5 5</dy>
+         <dz>5 1 6 5</dz>
+        </state>
+        <separation type="left">
+         <pieces count="3">0 3 5</pieces>
+         <state>
+          <dx>5 1 0</dx>
+          <dy>0 5 5</dy>
+          <dz>5 6 5</dz>
+         </state>
+         <state>
+          <dx>5 1 0</dx>
+          <dy>0 5 5</dy>
+          <dz>5 20006 5</dz>
+         </state>
+         <separation type="left">
+          <pieces count="2">0 5</pieces>
+          <state>
+           <dx>5 0</dx>
+           <dy>0 5</dy>
+           <dz>5 5</dz>
+          </state>
+          <state>
+           <dx>5 0</dx>
+           <dy>0 20005</dy>
+           <dz>5 5</dz>
+          </state>
+         </separation>
+     <assembly>5 0 5 15 6 5 1 21 1 1 0 0 1 5 6 2 1 6 5 13 0 5 5 23</assembly>
+        </separation>
+       </separation>
+      </separation>
+     </separation>
+    </solution>
+   </solutions>
+  </problem>
+ </problems>
+ <comment/>
+</puzzle>

--- a/test/malformed/too_many_voxels.xmpuzzle
+++ b/test/malformed/too_many_voxels.xmpuzzle
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<puzzle version="2">
+ <gridType type="0"/>
+ <colors/>
+ <shapes>
+  <voxel x="1" y="1" z="1" type="0">##</voxel>
+ </shapes>
+ <problems/>
+ <comment/>
+</puzzle>


### PR DESCRIPTION
Three out-of-bounds accesses reachable from the XML loader. In release builds the `bt_assert` bounds checks these paths relied on are compiled out (`NDEBUG`), so a crafted or corrupt `.xmpuzzle` produced real memory corruption instead of a clean parse error. Found with AddressSanitizer.

- **voxel content parsing** (`voxel.cpp`): the "too many voxels" check ran *after* `setState(idx++)` had already written, and used `>` instead of `>=`, so a content string with one extra state character wrote one past the end of the voxel space. The bounds check now precedes the write.
- **voxel dimensions** (`voxel.cpp`): `voxels = sx*sy*sz` was computed in a 32-bit field from unvalidated attributes. A negative or huge value (atoi wraps into unsigned) or a product exceeding 32 bits produced an allocation far too small for the coordinates that follow. Dimensions are now range-checked and the product computed in 64 bits before use.
- **solution loading** (`solution.cpp`): the file-loading constructor never initialised the `assembly` member pointer, so a `<solution>` with a `<separation>` before its `<assembly>` (or with none) tested, dereferenced and later deleted an uninitialised pointer. It is now initialised to 0, matching the other constructors.

Regression fixtures for all three are under `test/malformed/` with a README showing how to reproduce under a sanitizer build. All shipped example puzzles continue to load and solve identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)