### PR TITLE
Fix a mirror-info leak and signed-overflow UB in the disassembler hash

### DIFF
--- a/src/lib/assembler_0.cpp
+++ b/src/lib/assembler_0.cpp
@@ -741,8 +741,15 @@ assembler_0_c::errState assembler_0_c::createMatrix(bool keepMirror, bool keepRo
   pos = 0;
   iterations = 0;
 
-  if (keepMirror)
+  if (keepMirror) {
+    /* prepare() may already have allocated the mirror info via
+     * checkForTransformedAssemblies; free it before dropping the pointer
+     * (assembler_1_c::createMatrix does the same)
+     */
+    if (avoidTransformedMirror)
+      delete avoidTransformedMirror;
     avoidTransformedMirror = 0;
+  }
 
   if (keepRotations)
     avoidTransformedAssemblies = false;

--- a/src/lib/movementcache.cpp
+++ b/src/lib/movementcache.cpp
@@ -28,13 +28,18 @@
 
 /* the hash function. I don't know how well it performs, but it seems to be okay */
 static unsigned int moHashValue(unsigned int s1, unsigned int s2, int dx, int dy, int dz, unsigned char t1, unsigned char t2) {
-  unsigned int val = dx * 0x10101010;
-  val +=             dy * 0x14814814;
-  val +=             dz * 0x95145951;
-  val +=             t1 * 0x1A54941A;
-  val +=             t2 * 0x5AA59401;
-  val +=             s1 * 0x01059a04;
-  val +=             s2 * 0x9af42682;
+  /* unsigned constants so the multiplications are done in unsigned
+   * arithmetic; with signed int operands dx/dy/dz these products overflowed,
+   * which is undefined behaviour. The computed hash is unchanged: two's
+   * complement +/- and * agree with unsigned arithmetic modulo 2^32.
+   */
+  unsigned int val = dx * 0x10101010u;
+  val +=             dy * 0x14814814u;
+  val +=             dz * 0x95145951u;
+  val +=             t1 * 0x1A54941Au;
+  val +=             t2 * 0x5AA59401u;
+  val +=             s1 * 0x01059a04u;
+  val +=             s2 * 0x9af42682u;
   return val;
 }
 


### PR DESCRIPTION
Two small memory-safety / UB fixes found by sanitizers, neither of which changes solver results.

- **`assembler_0_c::createMatrix`** leaked the `mirrorInfo_c` that `prepare()` allocates via `checkForTransformedAssemblies`: when `keepMirror` was set it overwrote `avoidTransformedMirror` with 0 without freeing it. It now deletes first, matching `assembler_1_c::createMatrix`. Leaked once per create/solve cycle with `keepMirror` enabled.
- **`movementcache` `moHashValue`** multiplied signed `int` coordinates (dx/dy/dz) by large `int` constants, overflowing `int` on essentially every disassembly probe (undefined behaviour, flagged by UBSan). The constants are now unsigned so the arithmetic is done in `unsigned int`. The hash value is unchanged — two's-complement `+`/`*` agree with unsigned arithmetic modulo 2^32 — so disassembly results are identical (verified: level output byte-for-byte equal on the example puzzles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)