### PR TITLE
Add STL export of an assembled solution

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -1721,6 +1721,17 @@ void mainWindow_c::cb_STLExport(void) {
   }
 }
 
+static void cb_SolutionStlExport_stub(Fl_Widget* /*o*/, void* v) { ((mainWindow_c*)v)->cb_SolutionStlExport(); }
+void mainWindow_c::cb_SolutionStlExport(void) {
+  stlExport_c w(puzzle);
+  w.selectSolution(solutionProblem->getSelection(), (unsigned int)SolutionSel->value()-1);
+  w.show();
+
+  while (w.visible()) {
+    Fl::wait();
+  }
+}
+
 static void cb_StatusWindow_stub(Fl_Widget* /*o*/, void* v) { ((mainWindow_c*)v)->cb_StatusWindow(); }
 void mainWindow_c::cb_StatusWindow(void) {
 
@@ -2598,6 +2609,19 @@ void mainWindow_c::updateInterface(void) {
       {
         BtnMovement->deactivate();
       }
+
+      if (ggt->getGridType()->getCapabilities() & gridType_c::CAP_STLEXPORT &&
+          !assmThread &&
+          solutionProblem->getSelection() < puzzle->getNumberOfProblems() &&
+          SolutionSel->value()-1 < puzzle->getProblem(solutionProblem->getSelection())->getNumberOfSavedSolutions()
+         )
+      {
+        BtnSolutionSTL->activate();
+      }
+      else
+      {
+        BtnSolutionSTL->deactivate();
+      }
     } else {
 
       // no valid problem available, hide all information
@@ -2616,6 +2640,7 @@ void mainWindow_c::updateInterface(void) {
 
       BtnPlacement->deactivate();
       BtnMovement->deactivate();
+      BtnSolutionSTL->deactivate();
       if (BtnStep) BtnStep->deactivate();
       if (BtnPrepare) BtnPrepare->deactivate();
 
@@ -2738,6 +2763,7 @@ void mainWindow_c::updateInterface(void) {
         BtnDisasmAdd->deactivate();
         BtnDisasmAddAll->deactivate();
         BtnDisasmAddMissing->deactivate();
+        BtnSolutionSTL->deactivate();
 
       } else {
 
@@ -3670,6 +3696,9 @@ void mainWindow_c::CreateSolveTab(void) {
     (new LFl_Box(7, 0))->setMinimumSize(SZ_GAP, 0);
     BtnDisasmAddMissing=new LFlatButton_c(8, 0, 1, 1, "A M DA", " Recalculate the missing disassemblies for all solutions without valid disassembly ", cb_AddMissingDisasm_stub, this);
     ((LFlatButton_c*)BtnDisasmAddMissing)->weight(1, 0);
+    (new LFl_Box(9, 0))->setMinimumSize(SZ_GAP, 0);
+    BtnSolutionSTL = new LFlatButton_c(10, 0, 1, 1, "STL", " Export this solution as STL, all pieces in their assembled arrangement ", cb_SolutionStlExport_stub, this);
+    ((LFlatButton_c*)BtnSolutionSTL)->weight(1, 0);
 
     o->end();
 

--- a/src/gui/mainwindow.h
+++ b/src/gui/mainwindow.h
@@ -136,6 +136,7 @@ class mainWindow_c : public LFl_Double_Window {
   FlatButton *BtnSrtFind, *BtnSrtLevel, *BtnSrtMoves, *BtnSrtPieces;
   FlatButton *BtnDelAll, *BtnDelBefore, *BtnDelAt, *BtnDelAfter, *BtnDelDisasm;
   FlatButton *BtnDisasmDel, *BtnDisasmDelAll, *BtnDisasmAdd, *BtnDisasmAddAll, *BtnDisasmAddMissing;
+  FlatButton *BtnSolutionSTL;
 
   // the zoom levels for all 3 tabs independent, so that the problem
   // tab can have a wider view
@@ -285,6 +286,7 @@ public:
   void cb_ImageExport(void);
   void cb_ImageExportVector(void);
   void cb_STLExport(void);
+  void cb_SolutionStlExport(void);
   void cb_StatusWindow(void);
 
   void cb_SortSolutions(unsigned int by);

--- a/src/gui/stlexport.cpp
+++ b/src/gui/stlexport.cpp
@@ -82,6 +82,23 @@ bool stlExport_c::solutionMode(void) {
   return ExpSolution->value() != 0;
 }
 
+void stlExport_c::selectSolution(unsigned int prob, unsigned int sol) {
+
+  if (prob >= puzzle->getNumberOfProblems())
+    return;
+  if (sol >= puzzle->getProblem(prob)->getNumberOfSavedSolutions())
+    return;
+
+  ExpSolution->setonly();
+  ProblemSelect->setSelection(prob);
+
+  char txt[20];
+  snprintf(txt, 20, "%u", sol+1);
+  SolutionNum->value(txt);
+
+  cb_Update3DView(1);
+}
+
 std::vector<voxel_c *> stlExport_c::solutionSpaces(void) {
 
   std::vector<voxel_c *> res;

--- a/src/gui/stlexport.cpp
+++ b/src/gui/stlexport.cpp
@@ -28,10 +28,14 @@
 #include "buttongroup.h"
 
 #include "../lib/puzzle.h"
+#include "../lib/problem.h"
+#include "../lib/solution.h"
+#include "../lib/assembly.h"
 #include "../lib/gridtype.h"
 #include "../lib/bt_assert.h"
 #include "../lib/voxel.h"
 
+#include "../halfedge/polyhedron.h"
 #include "../halfedge/volume.h"
 
 
@@ -67,8 +71,32 @@ static void cb_stlExportExport_stub(Fl_Widget* /*o*/, void* v) { ((stlExport_c*)
 
 void stlExport_c::cb_Export(void) {
 
-  exportSTL(ShapeSelect->getSelection());
+  if (solutionMode())
+    exportSolutionSTL();
+  else
+    exportSTL(ShapeSelect->getSelection());
 
+}
+
+bool stlExport_c::solutionMode(void) {
+  return ExpSolution->value() != 0;
+}
+
+std::vector<voxel_c *> stlExport_c::solutionSpaces(void) {
+
+  std::vector<voxel_c *> res;
+
+  if (ProblemSelect->getSelection() >= puzzle->getNumberOfProblems())
+    return res;
+
+  const problem_c * pr = puzzle->getProblem(ProblemSelect->getSelection());
+
+  int sol = atoi(SolutionNum->value()) - 1;
+
+  if (sol < 0 || sol >= (int)pr->getNumberOfSavedSolutions())
+    return res;
+
+  return pr->getSavedSolution(sol)->getAssembly()->createPieceSpaces(*pr);
 }
 
 static void updateParameters(stlExporter_c * stl, const std::vector<inputField_c *> & params)
@@ -93,6 +121,39 @@ static void updateParameters(stlExporter_c * stl, const std::vector<inputField_c
   }
 }
 
+/* appends a copy of all faces of the source polyhedron to the destination */
+static void appendPolyhedron(Polyhedron * dst, vertexList_c & vl, const Polyhedron * src)
+{
+  std::vector<int> corners;
+
+  for (Polyhedron::const_face_iterator it = src->fBegin(); it != src->fEnd(); it++)
+  {
+    const Face * f = *it;
+
+    if (f->hole())
+      continue;
+
+    corners.clear();
+
+    Face::const_edge_circulator e = f->begin();
+    Face::const_edge_circulator sentinel = e;
+
+    do
+    {
+      const Vector3Df & pos = (*e)->dst()->position();
+      corners.push_back(vl.get(pos.x(), pos.y(), pos.z()));
+      e++;
+    } while (e != sentinel);
+
+    Face * f2 = dst->addFace(corners);
+
+    f2->_flags = f->_flags;
+    f2->_color = f->_color;
+    f2->_fb_index = f->_fb_index;
+    f2->_fb_face = f->_fb_face;
+  }
+}
+
 static void cb_stlExport3DUpdate_stub(Fl_Widget* /*o*/, void* v) { ((stlExport_c*)(v))->cb_Update3DView(1); }
 static void cb_stlExport3DUpdate2_stub(Fl_Widget* /*o*/, void* v) { ((stlExport_c*)(v))->cb_Update3DView(2); }
 void stlExport_c::cb_Update3DView(int type)
@@ -102,6 +163,63 @@ void stlExport_c::cb_Update3DView(int type)
   if (type == 2)
   {
     holes.clear();
+  }
+
+  if (solutionMode())
+  {
+    std::vector<voxel_c *> spaces = solutionSpaces();
+
+    if (spaces.empty())
+    {
+      view3D->getView()->showNothing();
+      status->label("No solution selected");
+      return;
+    }
+
+    Polyhedron * all = new Polyhedron();
+    vertexList_c vl(all);
+    double vol = 0;
+    faceList_c noHoles;
+
+    for (unsigned int i = 0; i < spaces.size(); i++)
+    {
+      Polyhedron * p = 0;
+
+      try
+      {
+        p = stl->getMesh(*spaces[i], noHoles);
+      }
+      catch (stlException_c e)
+      {
+        fl_message("%s",e.comment);
+      }
+      catch (...)
+      {
+        fl_message("The generated mesh is faulty in some way, try to tweak the parameter");
+      }
+
+      if (!p)
+      {
+        for (unsigned int j = 0; j < spaces.size(); j++)
+          delete spaces[j];
+        delete all;
+        return;
+      }
+
+      vol += volume(*p);
+      appendPolyhedron(all, vl, p);
+      delete p;
+    }
+
+    for (unsigned int j = 0; j < spaces.size(); j++)
+      delete spaces[j];
+
+    view3D->getView()->showMesh(all);
+    char txt[100];
+    snprintf(txt, 99, "%u pieces, volume: %1.1f cubic-units\n", (unsigned int)spaces.size(), vol);
+    status->copy_label(txt);
+
+    return;
   }
 
   Polyhedron * p = 0;
@@ -185,6 +303,10 @@ void stlExport_c::cb_Update3DViewParams(void)
 static void cb_3dClick_stub(Fl_Widget* /*o*/, void* v) { ((stlExport_c*)v)->cb_3dClick(); }
 void stlExport_c::cb_3dClick(void)
 {
+  // the hole selection only works on a single shape
+  if (solutionMode())
+    return;
+
   if (Fl::event_ctrl() || Fl::event_shift())
   {
     unsigned int shape, face;
@@ -350,6 +472,41 @@ stlExport_c::stlExport_c(puzzle_c * p) : LFl_Double_Window(true), puzzle(p) {
   {
     fr = new LFl_Frame(0, 3, 1, 1);
 
+    ExpShape = new LFl_Radio_Button("Export single shape", 0, 0, 3, 1);
+    ExpShape->value(1);
+    ExpShape->callback(cb_stlExport3DUpdate_stub, this);
+    ExpShape->tooltip(" Export the shape selected in the list above ");
+
+    ExpSolution = new LFl_Radio_Button("Export assembled solution", 0, 1, 3, 1);
+    ExpSolution->callback(cb_stlExport3DUpdate_stub, this);
+    ExpSolution->tooltip(" Export all pieces of a solution in their assembled arrangement, each piece gets its own offset and bevel ");
+
+    ProblemSelect = new ProblemSelector(0, 0, 20, 20, puzzle);
+    ProblemSelect->setSelection(0);
+
+    LBlockListGroup_c * gr = new LBlockListGroup_c(0, 2, 3, 1, ProblemSelect);
+    gr->callback(cb_stlExport3DUpdate_stub, this);
+    gr->setMinimumSize(200, 60);
+    gr->tooltip(" Select the problem whose solution to export ");
+
+    (new LFl_Box("Solution number", 0, 3))->stretchLeft();
+    (new LFl_Box(1, 3))->setMinimumSize(5, 0);
+
+    SolutionNum = new LFl_Int_Input(2, 3, 1, 1);
+    SolutionNum->value("1");
+    SolutionNum->weight(1, 0);
+    SolutionNum->callback(cb_stlExport3DUpdate_stub, this);
+    SolutionNum->tooltip(" Number of the solution to export, as shown in the solution tab ");
+
+    if (puzzle->getNumberOfProblems() == 0)
+      ExpSolution->deactivate();
+
+    fr->end();
+  }
+
+  {
+    fr = new LFl_Frame(0, 4, 1, 1);
+
     layouter_c * l = new layouter_c(0, 0, 1, 1);
     l->pitch(5);
 
@@ -365,7 +522,7 @@ stlExport_c::stlExport_c(puzzle_c * p) : LFl_Double_Window(true), puzzle(p) {
   }
 
   {
-    layouter_c * l = new layouter_c(0, 4, 2, 1);
+    layouter_c * l = new layouter_c(0, 5, 2, 1);
 
     status = new LFl_Box(0, 0, 1, 1);
     status->box(FL_UP_BOX);
@@ -389,7 +546,7 @@ stlExport_c::stlExport_c(puzzle_c * p) : LFl_Double_Window(true), puzzle(p) {
     l->end();
   }
 
-  view3D = new LView3dGroup(1, 0, 1, 4);
+  view3D = new LView3dGroup(1, 0, 1, 5);
   view3D->setMinimumSize(400, 400);
   view3D->weight(1, 0);
   view3D->callback(cb_3dClick_stub, this);
@@ -433,6 +590,57 @@ void stlExport_c::exportSTL(int shape)
   {
     fl_message("The generated mesh is faulty in some way, try to tweak the parameter");
   }
+}
+
+void stlExport_c::exportSolutionSTL(void)
+{
+  char name[1000];
+
+  std::vector<voxel_c *> spaces = solutionSpaces();
+
+  if (spaces.empty())
+  {
+    fl_message("Please select a problem and a valid solution number");
+    return;
+  }
+
+  updateParameters(stl, params);
+
+  stl->setBinaryMode(Binary->value() != 0);
+
+  if (Pname->value() && Pname->value()[0] && Pname->value()[strlen(Pname->value())-1] != '/') {
+      snprintf(name, 1000, "%s/%s", Pname->value(), Fname->value());
+  } else {
+      snprintf(name, 1000, "%s%s", Pname->value(), Fname->value());
+  }
+
+  if (fileExists(name))
+  {
+    if (fl_choice("File exists overwrite?", "Cancel", "Overwrite", 0) == 0)
+    {
+      for (unsigned int i = 0; i < spaces.size(); i++)
+        delete spaces[i];
+      return;
+    }
+  }
+
+  std::vector<const voxel_c *> shapes(spaces.begin(), spaces.end());
+  faceList_c noHoles;
+
+  try {
+    stl->write(name, shapes, noHoles);
+  }
+
+  catch (stlException_c e) {
+    fl_message("%s",e.comment);
+  }
+  catch (...)
+  {
+    fl_message("The generated mesh is faulty in some way, try to tweak the parameter");
+  }
+
+  for (unsigned int i = 0; i < spaces.size(); i++)
+    delete spaces[i];
 }
 
 stlExport_c::~stlExport_c(void)

--- a/src/gui/stlexport.h
+++ b/src/gui/stlexport.h
@@ -85,6 +85,10 @@ class stlExport_c : public LFl_Double_Window {
     stlExport_c(puzzle_c * p);
     virtual ~stlExport_c(void);
 
+    /* switch the dialog to assembled solution mode with the given
+     * problem and solution preselected */
+    void selectSolution(unsigned int prob, unsigned int sol);
+
     void cb_Export(void);
     void cb_Abort(void);
     void cb_Update3DView(int type);

--- a/src/gui/stlexport.h
+++ b/src/gui/stlexport.h
@@ -44,7 +44,9 @@
 class LView3dGroup;
 class LBlockListGroup;
 class puzzle_c;
+class voxel_c;
 class PieceSelector;
+class ProblemSelector;
 class ButtonGroup_c;
 
 class stlExporter_c;
@@ -68,7 +70,9 @@ class stlExport_c : public LFl_Double_Window {
     LFl_Box *status;
     LFl_Button *BtnStart, *BtnAbbort;
     PieceSelector * ShapeSelect;
-    // LFl_Radio_Button *ExpShape; // Unused?
+    ProblemSelector * ProblemSelect;
+    LFl_Radio_Button *ExpShape, *ExpSolution;
+    LFl_Int_Input *SolutionNum;
     LFl_Check_Button *Binary;
     ButtonGroup_c * mode;
 
@@ -86,8 +90,19 @@ class stlExport_c : public LFl_Double_Window {
     void cb_Update3DView(int type);
     void cb_Update3DViewParams(void);
     void exportSTL(int shape);
+    void exportSolutionSTL(void);
     void cb_3dClick(void);
     void cb_FileChooser(void);
+
+  private:
+
+    /* true, when the assembled solution mode is selected */
+    bool solutionMode(void);
+
+    /* the pieces of the selected solution, each in its own voxel space,
+     * all spaces have the size of the whole assembly. Empty when there
+     * is no valid solution selected */
+    std::vector<voxel_c *> solutionSpaces(void);
 };
 
 #endif

--- a/src/halfedge/polyhedron.cpp
+++ b/src/halfedge/polyhedron.cpp
@@ -212,7 +212,7 @@ void Polyhedron::finalize(void)
     int n = 0;
     {
       map<pair<int,int>, HalfEdge*>::iterator cit2 = cit;
-      while (cit2->first == idx)
+      while (cit2 != connections.end() && cit2->first == idx)
       {
         n++;
         cit2++;
@@ -297,7 +297,7 @@ void Polyhedron::finalize(void)
       projection(cit->second->dst()->position(), A, Ox, Oy);
       float baseA = -1;
 
-      while (cit->first == idx)
+      while (cit != connections.end() && cit->first == idx)
       {
         float Px, Py;
         projection(cit->second->next()->dst()->position(), A, Px, Py);

--- a/src/lib/assembly.cpp
+++ b/src/lib/assembly.cpp
@@ -809,7 +809,7 @@ voxel_c * assembly_c::createSpace(const problem_c & puz) const {
 
       voxel_c * pc = puz.getPuzzle().getGridType()->getVoxel(puz.getPartShape(j));
 
-      bt_assert(pc->transform(placements[i].transformation));
+      bt_assert2(pc->transform(placements[i].transformation));
 
       int dx = (int)placements[i].xpos - (int)pc->getHx();
       int dy = (int)placements[i].ypos - (int)pc->getHy();

--- a/src/lib/assembly.cpp
+++ b/src/lib/assembly.cpp
@@ -851,6 +851,69 @@ voxel_c * assembly_c::createSpace(const problem_c & puz) const {
   return res;
 }
 
+std::vector<voxel_c *> assembly_c::createPieceSpaces(const problem_c & puz) const {
+
+  std::vector<voxel_c *>pieces;
+  pieces.resize(placements.size());
+
+  int maxX = 1;
+  int maxY = 1;
+  int maxZ = 1;
+
+  // iterate over all shapes in the assembly and find out their placement
+  // to calculate the size of the whole assembly
+  for (unsigned int i = 0; i < placements.size(); i++)
+    if (placements[i].transformation != UNPLACED_TRANS) {
+
+      unsigned int j = puz.getPartIdToPieceId(i);
+
+      voxel_c * pc = puz.getPuzzle().getGridType()->getVoxel(puz.getPartShape(j));
+
+      bt_assert2(pc->transform(placements[i].transformation));
+
+      int dx = (int)placements[i].xpos - (int)pc->getHx();
+      int dy = (int)placements[i].ypos - (int)pc->getHy();
+      int dz = (int)placements[i].zpos - (int)pc->getHz();
+
+      if ((int)pc->getX()+dx > maxX) maxX = (int)pc->getX()+dx;
+      if ((int)pc->getY()+dy > maxY) maxY = (int)pc->getY()+dy;
+      if ((int)pc->getZ()+dz > maxZ) maxZ = (int)pc->getZ()+dz;
+
+      pieces[i] = pc;
+    }
+
+  std::vector<voxel_c *> res;
+
+  // place each piece into its own space of the size of the whole assembly
+  for (unsigned int i = 0; i < placements.size(); i++)
+    if (placements[i].transformation != UNPLACED_TRANS) {
+
+      voxel_c * pc = pieces[i];
+
+      int dx = (int)placements[i].xpos - (int)pc->getHx();
+      int dy = (int)placements[i].ypos - (int)pc->getHy();
+      int dz = (int)placements[i].zpos - (int)pc->getHz();
+
+      voxel_c * space = puz.getPuzzle().getGridType()->getVoxel(maxX, maxY, maxZ, 0);
+      space->skipRecalcBoundingBox(true);
+
+      for (unsigned int x = 0; x < pc->getX(); x++)
+        for (unsigned int y = 0; y < pc->getY(); y++)
+          for (unsigned int z = 0; z < pc->getZ(); z++) {
+            if (pc->getState(x, y, z) != voxel_c::VX_EMPTY)
+              space->set(x+dx, y+dy, z+dz, pc->get(x, y, z));
+          }
+
+      delete pc;
+
+      space->skipRecalcBoundingBox(false);
+      space->initHotspot();
+      res.push_back(space);
+    }
+
+  return res;
+}
+
 void assembly_c::removePieces(unsigned int from, unsigned int cnt)
 {
   if (cnt == 0) return;

--- a/src/lib/assembly.h
+++ b/src/lib/assembly.h
@@ -326,6 +326,14 @@ public:
    */
   voxel_c * createSpace(const problem_c & puz) const;
 
+  /** calculate one voxelspace per placed piece of the assembly. All
+   * spaces have the same size (that of the whole assembly) so that
+   * the pieces keep their placement relative to one another. This is
+   * used to export an assembled solution where each piece is handled
+   * separately (e.g. STL export with per piece offset and bevel)
+   */
+  std::vector<voxel_c *> createPieceSpaces(const problem_c & puz) const;
+
   void removePieces(unsigned int from, unsigned int cnt);
 
   void addNonPlacedPieces(unsigned int from, unsigned int cnt);

--- a/src/lib/stl.cpp
+++ b/src/lib/stl.cpp
@@ -57,54 +57,9 @@ const char * basename(const char * name) {
 #endif
 
 
-void stlExporter_c::write(const char * fname, const voxel_c & v, const faceList_c & holes)
+/** write all triangles of one polyhedron to an already opened STL file */
+static void writeTriangles(FILE * f, bool binaryMode, const Polyhedron * poly, unsigned long & triangleCount)
 {
-  FILE * f;
-  unsigned long triangleCount = 0;
-
-  const char * title = basename(fname);
-
-  if (binaryMode)
-  {
-    f = fopen(fname,"wb");
-
-    if (!f) throw stlException_c("Could not open file");
-
-    int pos = 0;
-
-    for (int i = 0; i < 84; i++)
-    {
-      if (fwrite(title+pos, 1, 1, f) != 1) throw stlException_c("Could not write file");
-      if (title[pos]) pos++;
-    }
-  }
-  else
-  {
-    f = fopen(fname,"w");
-
-    if (!f) throw stlException_c("Could not open file");
-
-    fprintf(f, "solid %s\n", title);
-  }
-
-  // try to generate the polyhedron, there might be problems along the way,
-  // like wrong parameters, or things like that, so we need to catch those
-  // cases and close the file, if that happens
-
-  Polyhedron * poly = 0;
-
-  try
-  {
-    poly = getMesh(v, holes);
-    if (!poly) throw stlException_c("Something went wrong when generating the STL polyhedron");
-  }
-  catch (stlException_c & e)
-  {
-    fclose(f);
-    throw e;
-  }
-
-  // write out the generated polyhedron
   for(Polyhedron::const_face_iterator it=poly->fBegin(); it!=poly->fEnd(); it++)
   {
     const Face* fc = *it;
@@ -156,8 +111,69 @@ void stlExporter_c::write(const char * fname, const voxel_c & v, const faceList_
       }
     } while (e != sentinel);
   }
+}
 
-  delete poly;
+void stlExporter_c::write(const char * fname, const voxel_c & v, const faceList_c & holes)
+{
+  std::vector<const voxel_c *> shapes;
+  shapes.push_back(&v);
+  write(fname, shapes, holes);
+}
+
+void stlExporter_c::write(const char * fname, const std::vector<const voxel_c *> & shapes, const faceList_c & holes)
+{
+  FILE * f;
+  unsigned long triangleCount = 0;
+
+  const char * title = basename(fname);
+
+  if (binaryMode)
+  {
+    f = fopen(fname,"wb");
+
+    if (!f) throw stlException_c("Could not open file");
+
+    int pos = 0;
+
+    for (int i = 0; i < 84; i++)
+    {
+      if (fwrite(title+pos, 1, 1, f) != 1) throw stlException_c("Could not write file");
+      if (title[pos]) pos++;
+    }
+  }
+  else
+  {
+    f = fopen(fname,"w");
+
+    if (!f) throw stlException_c("Could not open file");
+
+    fprintf(f, "solid %s\n", title);
+  }
+
+  // try to generate the polyhedra, there might be problems along the way,
+  // like wrong parameters, or things like that, so we need to catch those
+  // cases and close the file, if that happens
+
+  for (unsigned int s = 0; s < shapes.size(); s++)
+  {
+    Polyhedron * poly = 0;
+
+    try
+    {
+      poly = getMesh(*shapes[s], holes);
+      if (!poly) throw stlException_c("Something went wrong when generating the STL polyhedron");
+    }
+    catch (stlException_c & e)
+    {
+      fclose(f);
+      throw e;
+    }
+
+    // write out the generated polyhedron
+    writeTriangles(f, binaryMode, poly, triangleCount);
+
+    delete poly;
+  }
 
   if (binaryMode)
   {

--- a/src/lib/stl.h
+++ b/src/lib/stl.h
@@ -62,6 +62,14 @@ class stlExporter_c {
      */
     void write(const char * basename, const voxel_c & shape, const faceList_c & holes);
 
+    /**
+     * This function exports several shapes into one file. Each shape is
+     * meshed on its own (with its own bevel and offset), so this can be
+     * used to export an assembled solution where all the pieces are kept
+     * separate but stay in their place in the assembly
+     */
+    void write(const char * basename, const std::vector<const voxel_c *> & shapes, const faceList_c & holes);
+
     /** parameters can have different type
      * this enum lists all supported types
      */


### PR DESCRIPTION
Adds a second mode to the STL export dialog: instead of a single shape you can export all pieces of a saved solution in their assembled arrangement. Each piece is meshed individually with the regular exporter parameters (offset, bevel, etc.), so the result is one STL file containing separate solids for the pieces, positioned as assembled, with the gaps the offset produces between them. Useful for printing or displaying an assembled model, or importing pre-arranged pieces into a slicer.

The dialog gains radio buttons for **single shape** / **assembled solution**, a problem selector and a solution number input; all exporter parameters stay adjustable and the 3D preview shows the assembled result live, just like the single-shape preview.

Implementation:

- `assembly_c::createPieceSpaces()` creates one voxel space per placed piece of an assembly (same placement logic as `createSpace()`). All spaces get the size of the whole assembly, so the pieces keep their relative placement — which makes the mesh generators of every grid type position the pieces correctly without any mesh-level transformations.
- `stlExporter_c::write()` gets an overload taking several shapes that writes them into a single STL file (the existing single-shape `write` now delegates to it).
- The dialog preview merges the per-piece meshes into one polyhedron for display and reports piece count and total volume.

**Update:** the solution tab also gets an **STL** button (next to the disassembly buttons) that opens this dialog directly in assembled-solution mode with the currently viewed problem and solution preselected. Active whenever a solution is shown, the grid supports STL export, and the solver is not running.

Two bug fixes ride along because the feature exposed them:

- `Polyhedron::finalize()` dereferences `connections.end()` when the vertex pair being matched is the last key in the multimap (both counting and angle-sorting loops). This pre-existing UB in the shared STL meshing path crashed under ASan the moment several meshes were generated back to back. (Same fix as in #37; whichever lands first, the other rebases cleanly.)
- `assembly_c::createSpace()` wrapped the `pc->transform(...)` call in plain `bt_assert`, which compiles to *nothing* under NDEBUG — so in `-Db_ndebug=true` builds, "Import Assms" placed every piece untransformed. Now uses `bt_assert2`, which keeps evaluating its expression.

Verified headlessly on every example puzzle (all grid types — cubes, spheres, rhombic, tetra-octa, triangular prisms): for every saved solution, the per-piece spaces have zero overlaps and their union is voxel-identical to `createSpace()`'s merged result; STL export of each first solution succeeds and renders correctly (assembled model with per-piece seams), all ASan-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRdeB7d2VdaCNeCE5ARhVd
