### PR TITLE
Allow separate x, y and z unit sizes in the STL export

### DIFF
--- a/src/halfedge/modifiers.cpp
+++ b/src/halfedge/modifiers.cpp
@@ -436,6 +436,15 @@ void scalePolyhedron(Polyhedron & poly, float val)
    }
 }
 
+void scalePolyhedron(Polyhedron & poly, float x, float y, float z)
+{
+   for (Polyhedron::vertex_iterator it = poly.vBegin(); it != poly.vEnd(); it++)
+   {
+      const Vector3Df & p = (*it)->position();
+      (*it)->position(Vector3Df(p.x()*x, p.y()*y, p.z()*z));
+   }
+}
+
 static void joinTubePairs(Polyhedron & poly, Face *inside, Face *outside, float holeSize)
 {
   unsigned int i;

--- a/src/halfedge/modifiers.h
+++ b/src/halfedge/modifiers.h
@@ -48,6 +48,7 @@ class faceList_c {
 };
 
 void scalePolyhedron(Polyhedron & poly, float val);
+void scalePolyhedron(Polyhedron & poly, float x, float y, float z);
 void fillPolyhedronHoles(Polyhedron &poly, bool fillOutsides);
 
 // inverts the inv polyhedron and adds those faces to poly

--- a/src/halfedge/polyhedron.cpp
+++ b/src/halfedge/polyhedron.cpp
@@ -212,7 +212,7 @@ void Polyhedron::finalize(void)
     int n = 0;
     {
       map<pair<int,int>, HalfEdge*>::iterator cit2 = cit;
-      while (cit2->first == idx)
+      while (cit2 != connections.end() && cit2->first == idx)
       {
         n++;
         cit2++;
@@ -297,7 +297,7 @@ void Polyhedron::finalize(void)
       projection(cit->second->dst()->position(), A, Ox, Oy);
       float baseA = -1;
 
-      while (cit->first == idx)
+      while (cit != connections.end() && cit->first == idx)
       {
         float Px, Py;
         projection(cit->second->next()->dst()->position(), A, Px, Py);

--- a/src/lib/stl_0.cpp
+++ b/src/lib/stl_0.cpp
@@ -31,10 +31,16 @@ Polyhedron * stlExporter_0_c::getMesh(const voxel_c & v, const faceList_c & hole
 {
   if (v.countState(voxel_c::VX_VARIABLE)) throw stlException_c("Shapes with variable voxels cannot be exported");
   if (cube_scale < Epsilon) throw stlException_c("Unit size too small");
+  if (cube_scale_y < 0 || (cube_scale_y > 0 && cube_scale_y < Epsilon)) throw stlException_c("Unit size y too small");
+  if (cube_scale_z < 0 || (cube_scale_z > 0 && cube_scale_z < Epsilon)) throw stlException_c("Unit size z too small");
   if (shrink < 0) throw stlException_c("Offset cannot be negative");
   if (bevel < 0) throw stlException_c("Bevel cannot be negative");
   if (tubes > 1) throw stlException_c("Tubes size too large");
   if (!v.meshParamsValid(bevel/cube_scale, shrink/cube_scale)) throw stlException_c("Bevel and offset are not valid");
+
+  // the unit size in y and z direction defaults to the base unit size
+  double scale_y = (cube_scale_y > Epsilon) ? cube_scale_y : cube_scale;
+  double scale_z = (cube_scale_z > Epsilon) ? cube_scale_z : cube_scale;
 
   Polyhedron * poly = v.getMesh(bevel/cube_scale, shrink/cube_scale);
 
@@ -43,7 +49,7 @@ Polyhedron * stlExporter_0_c::getMesh(const voxel_c & v, const faceList_c & hole
     fillPolyhedronHoles(*poly, leaveGroovesOutside ? 0 : 1);
   }
 
-  scalePolyhedron(*poly, cube_scale);
+  scalePolyhedron(*poly, cube_scale, scale_y, scale_z);
 
   // we create inside void, when wall thickness is more than zero and not too
   // big to fill out the complete internal void (or better to let the
@@ -52,7 +58,7 @@ Polyhedron * stlExporter_0_c::getMesh(const voxel_c & v, const faceList_c & hole
   {
     Polyhedron * holePoly = v.getMesh(0, (hole+shrink)/cube_scale);
 
-    scalePolyhedron(*holePoly, cube_scale);
+    scalePolyhedron(*holePoly, cube_scale, scale_y, scale_z);
 
     if (smoothVoid)
     {
@@ -73,13 +79,15 @@ const char * stlExporter_0_c::getParameterName(unsigned int idx) const
   switch (idx)
   {
     case 0: return "Unit Size";
-    case 1: return "Bevel";
-    case 2: return "Offset";
-    case 3: return "Wall Thickness";
-    case 4: return "Tubes size";
-    case 5: return "Leave inside grooves";
-    case 6: return "Leave outside grooved";
-    case 7: return "Remove grooves in void";
+    case 1: return "Unit Size Y";
+    case 2: return "Unit Size Z";
+    case 3: return "Bevel";
+    case 4: return "Offset";
+    case 5: return "Wall Thickness";
+    case 6: return "Tubes size";
+    case 7: return "Leave inside grooves";
+    case 8: return "Leave outside grooved";
+    case 9: return "Remove grooves in void";
     default: return 0;
   }
 }
@@ -89,13 +97,15 @@ double stlExporter_0_c::getParameter(unsigned int idx) const
   switch (idx)
   {
     case 0: return cube_scale;
-    case 1: return bevel;
-    case 2: return shrink;
-    case 3: return hole;
-    case 4: return tubes;
-    case 5: return leaveGroovesInside ? 1 : 0;
-    case 6: return leaveGroovesOutside ? 1 : 0;
-    case 7: return smoothVoid ? 1 : 0;
+    case 1: return cube_scale_y;
+    case 2: return cube_scale_z;
+    case 3: return bevel;
+    case 4: return shrink;
+    case 5: return hole;
+    case 6: return tubes;
+    case 7: return leaveGroovesInside ? 1 : 0;
+    case 8: return leaveGroovesOutside ? 1 : 0;
+    case 9: return smoothVoid ? 1 : 0;
     default: return 0;
   }
 }
@@ -105,13 +115,15 @@ void stlExporter_0_c::setParameter(unsigned int idx, double value)
   switch (idx)
   {
     case 0: cube_scale = value; return;
-    case 1: bevel = value; return;
-    case 2: shrink = value; return;
-    case 3: hole = value; return;
-    case 4: tubes = value; return;
-    case 5: leaveGroovesInside  = (value != 0); return;
-    case 6: leaveGroovesOutside = (value != 0); return;
-    case 7: smoothVoid = (value != 0); return;
+    case 1: cube_scale_y = value; return;
+    case 2: cube_scale_z = value; return;
+    case 3: bevel = value; return;
+    case 4: shrink = value; return;
+    case 5: hole = value; return;
+    case 6: tubes = value; return;
+    case 7: leaveGroovesInside  = (value != 0); return;
+    case 8: leaveGroovesOutside = (value != 0); return;
+    case 9: smoothVoid = (value != 0); return;
     default: return;
   }
 }
@@ -120,15 +132,20 @@ const char * stlExporter_0_c::getParameterTooltip(unsigned int idx) const
 {
   switch (idx)
   {
-    case 0: return " Basic unit size of the voxel ";
-    case 1: return " Size of the bevel at the edges ";
-    case 2: return " By how much should faces be inset into the voxel ";
-    case 3: return " Thickness of the wall, 0 means the piece is completely filled ";
-    case 4: return " The size of the tubes that connect the inner void with the outside world. "
+    case 0: return " Basic unit size of the voxel, used for the x direction and as the "
+                    "default for the y and z direction ";
+    case 1: return " Unit size in the y direction, 0 means same as the basic unit size. "
+                    "Bevel and offset stretch along with a changed y unit ";
+    case 2: return " Unit size in the z direction, 0 means same as the basic unit size. "
+                    "Bevel and offset stretch along with a changed z unit ";
+    case 3: return " Size of the bevel at the edges ";
+    case 4: return " By how much should faces be inset into the voxel ";
+    case 5: return " Thickness of the wall, 0 means the piece is completely filled ";
+    case 6: return " The size of the tubes that connect the inner void with the outside world. "
                     "The size is relative to the face size. Biggest value 1 ";
-    case 5: return " Leave the construction grooves on the inside of the generated shape ";
-    case 6: return " Leave the construction grooves on the outside of the generated shape ";
-    case 7: return " Remove the grooves in the insiede void ";
+    case 7: return " Leave the construction grooves on the inside of the generated shape ";
+    case 8: return " Leave the construction grooves on the outside of the generated shape ";
+    case 9: return " Remove the grooves in the insiede void ";
 
     default: return "";
   }
@@ -143,11 +160,13 @@ stlExporter_c::parameterTypes stlExporter_0_c::getParameterType(unsigned int idx
     case 2:
     case 3:
     case 4:
-    default:
-      return PAR_TYP_POS_DOUBLE;
     case 5:
     case 6:
+    default:
+      return PAR_TYP_POS_DOUBLE;
     case 7:
+    case 8:
+    case 9:
       return PAR_TYP_SWITCH;
   }
 }

--- a/src/lib/stl_0.h
+++ b/src/lib/stl_0.h
@@ -28,10 +28,10 @@ class stlExporter_0_c : public stlExporter_c {
 
   public:
 
-    stlExporter_0_c(void) : bevel(0.3), cube_scale(10), shrink(0.01), hole(0), tubes(0.05), leaveGroovesInside(false), leaveGroovesOutside(false), smoothVoid(false) {}
+    stlExporter_0_c(void) : bevel(0.3), cube_scale(10), cube_scale_y(0), cube_scale_z(0), shrink(0.01), hole(0), tubes(0.05), leaveGroovesInside(false), leaveGroovesOutside(false), smoothVoid(false) {}
 
     virtual Polyhedron * getMesh(const voxel_c & v, const faceList_c & holes) const;
-    virtual unsigned int numParameters(void) const { return 8; }
+    virtual unsigned int numParameters(void) const { return 10; }
     virtual const char * getParameterName(unsigned int idx) const;
     virtual double getParameter(unsigned int idx) const;
     virtual void setParameter(unsigned int idx, double value);
@@ -42,6 +42,8 @@ class stlExporter_0_c : public stlExporter_c {
 
     double bevel;
     double cube_scale;
+    double cube_scale_y;  // unit size in y direction, 0 = same as cube_scale
+    double cube_scale_z;  // unit size in z direction, 0 = same as cube_scale
     double shrink;
     double hole;
     double tubes;  // size of the tubes that connect inside and outside


### PR DESCRIPTION
Adds **"Unit Size Y"** and **"Unit Size Z"** parameters to the brick STL exporter. Both default to 0, meaning "same as Unit Size" — existing behavior is unchanged. When set, the exported mesh is stretched along that axis, so puzzles can be printed with non-cubic unit cells.

Semantics: the mesh is generated in unit space exactly as before (so all `meshParamsValid` constraints are unchanged) and scaled per-axis at the end. Bevel and offset are exact at the base unit size and stretch proportionally along a resized axis — noted in the parameter tooltips.

Applies to every grid that uses the brick exporter (bricks, triangular prisms, rhombic, tetrahedra-octahedra). The sphere exporter is untouched since spheres can't be stretched. The export dialog needs no changes — parameters render generically.

The `Polyhedron::finalize()` past-the-end fix rides along as the first commit (same as #37/#38/#39; dedupes on merge).

Verified headlessly: exporting a burr piece at unit 10 with Y=15/Z=20 produces exactly 1.0/1.5/2.0 bounding-box ratios and exactly 3.0× volume versus the uniform export, watertight (all directed edges pair with their reverses) on both cube and rhombic grids, ASan-clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PRdeB7d2VdaCNeCE5ARhVd